### PR TITLE
fix(auth): set correct api version when username missing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## Unreleased
+
+### Fixed
+
+* The automatic backend API version detection is now more reliable in some edge cases. (#1)
+
 ## Version v0.1.0 - 2023-06-20
 
 Initial package release.

--- a/test/authentication.jl
+++ b/test/authentication.jl
@@ -3,26 +3,124 @@
     Mocking.apply(mocking_patch) do
         withenv("JULIA_PKG_SERVER" => nothing) do
             @test_throws JuliaHub.AuthenticationError JuliaHub.authenticate()
-            @test JuliaHub.authenticate("https://juliahub.com") isa JuliaHub.Authentication
-            @test JuliaHub.authenticate("juliahub.com") isa JuliaHub.Authentication
+            @test JuliaHub.authenticate("https://juliahub.example.org") isa JuliaHub.Authentication
+            @test JuliaHub.authenticate("juliahub.example.org") isa JuliaHub.Authentication
         end
-        withenv("JULIA_PKG_SERVER" => "juliahub.com") do
+        withenv("JULIA_PKG_SERVER" => "juliahub.example.org") do
             @test JuliaHub.authenticate() isa JuliaHub.Authentication
         end
-        withenv("JULIA_PKG_SERVER" => "https://juliahub.com") do
+        withenv("JULIA_PKG_SERVER" => "https://juliahub.example.org") do
             @test JuliaHub.authenticate() isa JuliaHub.Authentication
         end
         # Conflicting declarations, argument takes precendence
-        withenv("JULIA_PKG_SERVER" => "https://juliahub-one.com") do
-            auth = JuliaHub.authenticate("https://juliahub-two.com")
+        withenv("JULIA_PKG_SERVER" => "https://juliahub-one.example.org") do
+            auth = JuliaHub.authenticate("https://juliahub-two.example.org")
             @test auth isa JuliaHub.Authentication
-            @test auth.server == URIs.URI("https://juliahub-two.com")
+            @test auth.server == URIs.URI("https://juliahub-two.example.org")
             # check_authentication
             MOCK_JULIAHUB_STATE[:invalid_authentication] = false
             @test JuliaHub.check_authentication(; auth) === true
             MOCK_JULIAHUB_STATE[:invalid_authentication] = true
             @test JuliaHub.check_authentication(; auth) === false
             delete!(MOCK_JULIAHUB_STATE, :invalid_authentication)
+        end
+    end
+end
+
+# In the general authenticate() tests, we mock the call to JuliaHub._authenticate()
+# So here we call a lower level JuliaHub._authenticat**ion** implementation, with
+# the REST calls mocked.
+@testset "JuliaHub._authenticate()" begin
+    empty!(MOCK_JULIAHUB_STATE)
+    server = URIs.URI("https://juliahub.example.org")
+    token = JuliaHub.Secret("")
+    Mocking.apply(mocking_patch) do
+        let a = JuliaHub._authentication(server; token)
+            @test a isa JuliaHub.Authentication
+            @test a.server == server
+            @test a.username == MOCK_USERNAME
+            @test a.token == token
+            @test a._api_version == v"0.0.1"
+            @test a._email === nothing
+            @test a._expires === nothing
+        end
+        let a = JuliaHub._authentication(
+                server;
+                token,
+                username="authfile_username",
+                expires=1234,
+                email="authfile@example.org",
+            )
+            @test a isa JuliaHub.Authentication
+            @test a.server == server
+            @test a.username == MOCK_USERNAME
+            @test a._api_version == v"0.0.1"
+            @test a._email == "authfile@example.org"
+            @test a._expires == 1234
+        end
+        # On old instances, we handle if /api/v1 404s
+        MOCK_JULIAHUB_STATE[:auth_v1_status] = 404
+        let a = JuliaHub._authentication(
+                server;
+                token,
+                username="authfile_username",
+                expires=1234,
+                email="authfile@example.org",
+            )
+            @test a isa JuliaHub.Authentication
+            @test a.server == server
+            @test a.username == MOCK_USERNAME
+            @test a._api_version == JuliaHub._MISSING_API_VERSION
+            @test a._email == "testuser@example.org"
+            @test a._expires == 1234
+        end
+        # .. but on a 500, it will actually throw
+        MOCK_JULIAHUB_STATE[:auth_v1_status] = 500
+        @test_throws JuliaHub.AuthenticationError JuliaHub._authentication(
+            server;
+            token,
+            username="authfile_username",
+            expires=1234,
+            email="authfile@example.org"
+        )
+        # Testing the fallback to legacy GQL endpoint
+        MOCK_JULIAHUB_STATE[:auth_v1_status] = 404
+        let a = JuliaHub._authentication(
+                server;
+                token,
+                username="authfile_username",
+                email="authfile@example.org"
+            )
+            @test a isa JuliaHub.Authentication
+            @test a.server == server
+            @test a.username == MOCK_USERNAME
+            @test a._api_version == JuliaHub._MISSING_API_VERSION
+            @test a._email == "testuser@example.org"
+            @test a._expires === nothing
+        end
+        # Error when the fallback also 500s
+        MOCK_JULIAHUB_STATE[:auth_gql_fail] = true
+        @test_throws JuliaHub.AuthenticationError JuliaHub._authentication(
+            server;
+            token,
+            username="authfile_username",
+            expires=1234,
+            email="authfile@example.org"
+        )
+        # Missing username in /api/v1 -- succes, but with a warning
+        delete!(MOCK_JULIAHUB_STATE, :auth_v1_status)
+        MOCK_JULIAHUB_STATE[:auth_v1_username] = nothing
+        let a = @test_logs (:warn,) JuliaHub._authentication(
+                server;
+                token,
+                username="authfile_username",
+                email="authfile@example.org"
+            )
+            @test a isa JuliaHub.Authentication
+            @test a.server == server
+            @test a.username == "authfile_username"
+            @test a._api_version == v"0.0.1"
+            @test a._email == "authfile@example.org"
         end
     end
 end

--- a/test/mocking.jl
+++ b/test/mocking.jl
@@ -25,7 +25,7 @@ const MOCK_USERNAME = "username"
 mockauth(server_uri) = JuliaHub.Authentication(
     server_uri, JuliaHub._MISSING_API_VERSION, MOCK_USERNAME, JuliaHub.Secret("")
 )
-JuliaHub.__AUTH__[] = mockauth(URIs.URI("https://juliahub.com"))
+JuliaHub.__AUTH__[] = mockauth(URIs.URI("https://juliahub.example.org"))
 
 # The following Mocking.jl patches _rest_request, so the the rest calls would have fixed
 # reponses.
@@ -71,6 +71,15 @@ mocking_patch = [
             return mockauth(server_uri)
         end
     ),
+    Mocking.@patch(
+        JuliaHub._get_authenticated_user_legacy_gql_request(
+            ::AbstractString, ::JuliaHub.Secret
+        ) = _auth_legacy_gql_mocked()
+    ),
+    Mocking.@patch(
+        JuliaHub._get_authenticated_user_api_v1_request(::AbstractString, ::JuliaHub.Secret) =
+            _auth_apiv1_mocked()
+    )
 ]
 uuidhash(s::AbstractString) = only(reinterpret(UUIDs.UUID, SHA.sha1(s)[1:16]))
 function _restput_mocked(url::AbstractString, headers, input)
@@ -667,4 +676,42 @@ function serve_legacy(logengine::LogEngine, query::Dict)
         end
     end
     return JuliaHub._RESTResponse(200, string('"', escape_string(JSON.json(logs)), '"'))
+end
+
+# Authentication mocking
+function _auth_legacy_gql_mocked()
+    global MOCK_JULIAHUB_STATE
+    if get(MOCK_JULIAHUB_STATE, :auth_gql_fail, false)
+        return JuliaHub._RESTResponse(500, "auth_gql_fail = true")
+    end
+    return Dict{String, Any}(
+        "data" => Dict{String, Any}(
+            "users" => Any[Dict{String, Any}(
+                "name" => "Test User",
+                "firstname" => "Test",
+                "id" => 42,
+                "username" => "username",
+                "info" => Any[Dict{String, Any}(
+                    "email" => "testuser@example.org"
+                )],
+            )],
+        ),
+    ) |> jsonresponse(200)
+end
+
+function _auth_apiv1_mocked()
+    global MOCK_JULIAHUB_STATE, MOCK_USERNAME
+    status = get(MOCK_JULIAHUB_STATE, :auth_v1_status, 200)
+    if status != 200
+        return JuliaHub._RESTResponse(status, "auth_v1_status override")
+    end
+    d = Dict{String, Any}(
+        "timezone" => Dict{String, Any}("abbreviation" => "Etc/UTC", "utc_offset" => "+00:00"),
+        "api_version" => "0.0.1",
+    )
+    username = get(MOCK_JULIAHUB_STATE, :auth_v1_username, MOCK_USERNAME)
+    if !isnothing(username)
+        d["username"] = username
+    end
+    d |> jsonresponse(200)
 end

--- a/test/mocking.jl
+++ b/test/mocking.jl
@@ -25,7 +25,7 @@ const MOCK_USERNAME = "username"
 mockauth(server_uri) = JuliaHub.Authentication(
     server_uri, JuliaHub._MISSING_API_VERSION, MOCK_USERNAME, JuliaHub.Secret("")
 )
-JuliaHub.__AUTH__[] = mockauth(URIs.URI("https://juliahub.example.org"))
+JuliaHub.__AUTH__[] = mockauth(URIs.URI("https://juliahub.com"))
 
 # The following Mocking.jl patches _rest_request, so the the rest calls would have fixed
 # reponses.


### PR DESCRIPTION
When the username is not set in the `/api/v1` response (which can happen), that leads to an error and we then assume legacy compat for the APIs. This makes sure we extract the API version information from `/api/v1`, even if `username` is not set there. Also adds mocked tests for the various backend edge cases.