### PR TITLE
ci: add a JET.jl workflow

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -96,11 +96,11 @@ jobs:
           Pkg.add(name="JET", version="0.8")
           Pkg.develop(path=".")
       - name: "JET.test_package(..., mode=:basic) [informational]"
-        run: julia --color=yes --project=@juliahub-jet {0} test/jet.jl
+        run: julia --color=yes --project=@juliahub-jet test/jet.jl
         env:
           JULIAHUB_TEST_JET: basic
       - name: "JET.test_package(..., mode=:typo)"
-        run: julia --color=yes --project=@juliahub-jet {0} test/jet.jl
+        run: julia --color=yes --project=@juliahub-jet test/jet.jl
         continue-on-error: true
 
   docs:

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -80,6 +80,24 @@ jobs:
         name: "Aqua.test_all(JuliaHub)"
         continue-on-error: true
 
+  jet:
+    name: JET
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: julia-actions/setup-julia@v1
+        with:
+          version: "1"
+      - run: |
+          import Pkg
+          Pkg.activate(temp=true)
+          Pkg.add(name="JET", version="0.8")
+          Pkg.develop(path=".")
+          include("test/jet.jl")
+        shell: julia --color=yes {0}
+        name: "JET.test_package()"
+        continue-on-error: true
+
   docs:
     name: Documentation
     runs-on: ubuntu-latest

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -88,14 +88,19 @@ jobs:
       - uses: julia-actions/setup-julia@v1
         with:
           version: "1"
-      - run: |
+      - name: "Install dependencies"
+        shell: julia --color=yes {0}
+        run: |
           import Pkg
-          Pkg.activate(temp=true)
+          Pkg.activate("juliahub-jet", shared=true)
           Pkg.add(name="JET", version="0.8")
           Pkg.develop(path=".")
-          include("test/jet.jl")
-        shell: julia --color=yes {0}
-        name: "JET.test_package()"
+      - name: "JET.test_package()"
+        run: julia --color=yes --project=@juliahub-jet {0} test/jet.jl
+      - name: "JET.test_package(..., mode=:basic)"
+        run: julia --color=yes --project=@juliahub-jet {0} test/jet.jl
+        env:
+          JULIAHUB_TEST_JET: basic
         continue-on-error: true
 
   docs:

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -99,9 +99,9 @@ jobs:
         run: julia --color=yes --project=@juliahub-jet test/jet.jl
         env:
           JULIAHUB_TEST_JET: basic
+        continue-on-error: true
       - name: "JET.test_package(..., mode=:typo)"
         run: julia --color=yes --project=@juliahub-jet test/jet.jl
-        continue-on-error: true
 
   docs:
     name: Documentation

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -95,12 +95,12 @@ jobs:
           Pkg.activate("juliahub-jet", shared=true)
           Pkg.add(name="JET", version="0.8")
           Pkg.develop(path=".")
-      - name: "JET.test_package()"
-        run: julia --color=yes --project=@juliahub-jet {0} test/jet.jl
-      - name: "JET.test_package(..., mode=:basic)"
+      - name: "JET.test_package(..., mode=:basic) [informational]"
         run: julia --color=yes --project=@juliahub-jet {0} test/jet.jl
         env:
           JULIAHUB_TEST_JET: basic
+      - name: "JET.test_package(..., mode=:typo)"
+        run: julia --color=yes --project=@juliahub-jet {0} test/jet.jl
         continue-on-error: true
 
   docs:

--- a/README.md
+++ b/README.md
@@ -1,9 +1,9 @@
 # JuliaHub.jl ![BETA][beta-badge]
 
-<!-- [![Version][jh-version-img]][jh-version-url] -->
+[![Version][jh-version-img]][jh-version-url]
 [![][docs-stable-img]][docs-stable-url]
 [![][gha-img]][gha-url]
-<!-- [![][codecov-img]][codecov-url] -->
+[![][codecov-img]][codecov-url]
 
 A Julia client for the [JuliaHub platform][juliahub-com] APIs.
 It allows you to programmatically interact with the platform to, for example, upload or download datasets, start jobs, and so on.
@@ -48,7 +48,7 @@ If you are curious about changes and updates that new version have brought, see 
 [beta-badge]: https://img.shields.io/badge/-BETA-blue.svg
 
 [jh-version-img]: https://juliahub.com/docs/JuliaHub/version.svg
-[jh-version-url]: https://juliahub.com/ui/Packages/JuliaHub/...
+[jh-version-url]: https://juliahub.com/ui/Packages/JuliaHub/B9bPq/
 
 [docs-stable-img]: https://img.shields.io/badge/docs-help.juliahub.com-blue.svg
 [docs-stable-url]: https://help.juliahub.com/julia-api/stable/
@@ -58,7 +58,5 @@ If you are curious about changes and updates that new version have brought, see 
 [gha-img]: https://github.com/JuliaComputing/JuliaHub.jl/workflows/CI/badge.svg
 [gha-url]: https://github.com/JuliaComputing/JuliaHub.jl/actions?query=workflows/CI
 
-<!--
 [codecov-img]: https://codecov.io/gh/JuliaComputing/JuliaHub.jl/branch/main/graph/badge.svg
 [codecov-url]: https://codecov.io/gh/JuliaComputing/JuliaHub.jl
--->

--- a/src/authentication.jl
+++ b/src/authentication.jl
@@ -104,13 +104,14 @@ end
 const __AUTH__ = Ref{Union{Authentication, Nothing}}(nothing)
 # Internal function to populate the `auth` keyword of the various function
 # with the default, global authentication.
-function __auth__()
-    __AUTH__[] isa Authentication && return __AUTH__[]
+function __auth__()::Authentication
+    auth = __AUTH__[]
+    isa(auth, Authentication) && return auth
     auth = try
         authenticate()
-    catch e
+    catch
         @error "Automatic authentication failed, explicit `auth` keyword argument required."
-        rethrow(e)
+        rethrow()
     end
     return auth
 end

--- a/src/jobsubmission.jl
+++ b/src/jobsubmission.jl
@@ -372,9 +372,10 @@ end
 
 function _batchcompute_env_show(io::IO, script_env::_ScriptEnvironment)
     for s in (:project_toml, :manifest_toml, :artifacts_toml)
-        isnothing(getproperty(script_env, s)) && continue
+        toml = getproperty(script_env, s)
+        isnothing(toml) && continue
         print(io, "\nsha256($s) = ")
-        print(io, bytes2hex(SHA.sha256(getproperty(script_env, s))))
+        print(io, bytes2hex(SHA.sha256(toml)))
     end
 end
 function _batchcompute_env_show(io::IO, appbundle_env::_AppBundleEnvironment)

--- a/test/jet.jl
+++ b/test/jet.jl
@@ -1,6 +1,9 @@
 import JET, JuliaHub
 using Test
 
+jet_mode = Symbol(get(ENV, "JULIAHUB_TEST_JET", "typo"))
+@info "Running JET.jl in mode=:$(jet_mode)"
+
 @testset "JET" begin
-    JET.test_package("JuliaHub"; target_defined_modules=true, mode=:typo)
+    JET.test_package("JuliaHub"; target_defined_modules=true, mode=jet_mode)
 end

--- a/test/jet.jl
+++ b/test/jet.jl
@@ -1,0 +1,6 @@
+import JET, JuliaHub
+using Test
+
+@testset "JET" begin
+    JET.test_package("JuliaHub"; target_defined_modules=true, mode=:typo)
+end


### PR DESCRIPTION
Adds a simple JET.jl workflow to do some static checking. It just runs in `:typo` mode for now, since that one actually passes. I.e.

```julia
JET.test_package("JuliaHub"; target_defined_modules=true, mode=:type)
```

In addition, it also does an informational `:basic` pass, but that won't fail the workflow.

This should currently fail, but pass once #9 is merged.