### PR TITLE
test: fix permissions of PackageBundler test inputs

### DIFF
--- a/test/jobs.jl
+++ b/test/jobs.jl
@@ -1,5 +1,13 @@
+# We have to copy the test environment files to a temporary directory
+# because PackageBundler needs write access to them.
+JOBENVS = let tmp = tempname()
+    cp(joinpath(@__DIR__, "jobenvs"), tmp)
+    chmod(tmp, 0o777; recursive=true)
+    tmp
+end
+
 @testset "JuliaHub.script" begin
-    jobfile(path...) = joinpath(@__DIR__, "jobenvs", "job1", path...)
+    jobfile(path...) = joinpath(JOBENVS, "job1", path...)
 
     let s = JuliaHub.script(; code="1", project="name=1", manifest="name=1", artifacts="name=1")
         @test s.code == "1"
@@ -50,7 +58,7 @@
 end
 
 @testset "JuliaHub.appbundle" begin
-    jobfile(path...) = joinpath(@__DIR__, "jobenvs", "job1", path...)
+    jobfile(path...) = joinpath(JOBENVS, "job1", path...)
 
     bundle = JuliaHub.appbundle(jobfile(), "script.jl")
     @test isfile(bundle.environment.tarball_path)

--- a/test/packagebundler.jl
+++ b/test/packagebundler.jl
@@ -1,11 +1,14 @@
 import Tar
 
-tmp_fixtures = tempname()
-@show tmp_fixtures
-cp(joinpath(@__DIR__, "fixtures"), tmp_fixtures)
-chmod(tmp_fixtures, 0o777; recursive=true)
+# We have to copy the test environment files to a temporary directory
+# because PackageBundler needs write access to them.
+TMP_FIXTURES = let tmp = tempname()
+    cp(joinpath(@__DIR__, "fixtures"), tmp)
+    chmod(tmp, 0o777; recursive=true)
+    tmp
+end
 
-pkg1 = joinpath(tmp_fixtures, "ignorefiles", "Pkg1")
+pkg1 = joinpath(TMP_FIXTURES, "ignorefiles", "Pkg1")
 if !isdir(joinpath(pkg1, ".git"))
     mkdir(joinpath(pkg1, ".git")) # can't check in sub-repos
     touch(joinpath(pkg1, ".git", "test"))

--- a/test/packagebundler.jl
+++ b/test/packagebundler.jl
@@ -1,6 +1,10 @@
 import Tar
 
-pkg1 = joinpath(@__DIR__, "fixtures", "ignorefiles", "Pkg1")
+tmp_fixtures = tempname()
+cp(joinpath(@__DIR__, "fixtures"), tmp_fixtures)
+chmod(tmp_fixtures, 0o777; recursive=true)
+
+pkg1 = joinpath(tmp_fixtures, "ignorefiles", "Pkg1")
 if !isdir(joinpath(pkg1, ".git"))
     mkdir(joinpath(pkg1, ".git")) # can't check in sub-repos
     touch(joinpath(pkg1, ".git", "test"))

--- a/test/packagebundler.jl
+++ b/test/packagebundler.jl
@@ -1,6 +1,7 @@
 import Tar
 
 tmp_fixtures = tempname()
+@show tmp_fixtures
 cp(joinpath(@__DIR__, "fixtures"), tmp_fixtures)
 chmod(tmp_fixtures, 0o777; recursive=true)
 


### PR DESCRIPTION
This should fix JuliaHub.jl in PkgEval, where it's currently failing because it gets `Pkg.add`ed: https://s3.amazonaws.com/julialang-reports/nanosoldier/pkgeval/by_date/2023-07/04/JuliaHub.primary.log