### PR TITLE
Assortment of job-related fixes and improvements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 * The `name` keyword argument to `submit_job` has been deprecated and replaced with `alias`. (#13)
 
+### Fixed
+
+* `extend_job` now correctly handles the `200` but `success: false` response. (#13)
+
 ## Version v0.1.2 - 2023-06-26
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Release notes
 
-The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## Unreleased
 
@@ -16,7 +16,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## Version v0.1.1 - 2023-06-24
 
-### Added
+### Changed
 
 * The `JuliaHub.download_job_file` function now returns the path of the relevant local file. (#3)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## Unreleased
+## Version v0.1.3 - 2023-07-17
 
 ### Changed
 
@@ -11,6 +11,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 ### Fixed
 
 * `extend_job` now correctly handles the `200` but `success: false` response. (#13)
+* An assortment of small bugfixes revealed by JET. (#9) (#12)
+
+### Tests
+
+* The test suite now runs successfully when the package is `Pkg.add`ed and the package files have only read-only permissions. (#11)
 
 ## Version v0.1.2 - 2023-06-26
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## Unreleased
+
+### Changed
+
+* The `name` keyword argument to `submit_job` has been deprecated and replaced with `alias`. (#13)
+
 ## Version v0.1.2 - 2023-06-26
 
 ### Fixed

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "JuliaHub"
 uuid = "bc7fa6ce-b75e-4d60-89ad-56c957190b6e"
 authors = ["JuliaHub Inc."]
-version = "0.1.2"
+version = "0.1.3"
 
 [deps]
 Base64 = "2a0f44e3-6c83-55bd-87e4-b1978d98bd5f"

--- a/test/jobenvs/job-windows/script.jl
+++ b/test/jobenvs/job-windows/script.jl
@@ -1,11 +1,12 @@
 import TOML, SHA
 
 # Check for the appbundle file
-datafile = joinpath(pwd(), "appbundle", "datafile.txt")
-datafile_fallback = joinpath(pwd(), "datafile.txt")
+datafile = joinpath(@__DIR__, "appbundle", "datafile.txt")
+datafile_fallback = joinpath(@__DIR__, "datafile.txt")
 datafile_hash, fallback = if isfile(datafile)
     bytes2hex(open(SHA.sha1, datafile)), false
 elseif isfile(datafile_fallback)
+    @warn "Using fallback datafile path" datafile_fallback
     bytes2hex(open(SHA.sha1, datafile_fallback)), true
 else
     nothing, nothing

--- a/test/jobenvs/job1/script.jl
+++ b/test/jobenvs/job1/script.jl
@@ -5,7 +5,7 @@ toml = TOML.parsefile(projecttoml)
 datastructures_version = toml["version"]
 
 # Check for the appbundle file
-datafile = joinpath(pwd(), "appbundle", "datafile.txt")
+datafile = joinpath(@__DIR__, "appbundle", "datafile.txt")
 datafile_hash = if isfile(datafile)
     bytes2hex(open(SHA.sha1, datafile))
 end

--- a/test/jobs-live.jl
+++ b/test/jobs-live.jl
@@ -201,7 +201,7 @@ end
         ENV["RESULTS"] = JSON.json((; vs))
         """;
         ncpu=2, nnodes=3, process_per_node=false,
-        name="juliahubjl-$(TESTID)", env=Dict("FOO" => "bar"),
+        alias="juliahubjl-$(TESTID)", env=Dict("FOO" => "bar"),
         auth,
     )
     @test job.env["jobname"] == "juliahubjl-$(TESTID)"


### PR DESCRIPTION
* `name` -> `alias` in `submit_job` (with a deprecation)
* `extend_job` handles `200` `success: false` responses now
* The live job tests now print some at-infos, and also set a nice job alias (to make it easier to identify the jobs in the UI).
  
  ![image](https://github.com/JuliaComputing/JuliaHub.jl/assets/147757/27845c25-4d4e-4f10-b300-04219577ffb7)

* Use `@__DIR__` in appbundle live tests.
* Also update the CHANGELOG and set version to `v0.1.3` for tagging.