### PR TITLE
fix: do not use the deprecated JLL do form

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## Version v0.1.4
+
+### Fixed
+
+* `upload_dataset` and `download_dataset` no longer use the deprecated do-syntax to call the `rclone` binary. (#18)
+
 ## Version v0.1.3 - 2023-07-17
 
 ### Changed

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "JuliaHub"
 uuid = "bc7fa6ce-b75e-4d60-89ad-56c957190b6e"
 authors = ["JuliaHub Inc."]
-version = "0.1.3"
+version = "0.1.4"
 
 [deps]
 Base64 = "2a0f44e3-6c83-55bd-87e4-b1978d98bd5f"

--- a/src/datasets.jl
+++ b/src/datasets.jl
@@ -665,7 +665,7 @@ function _upload_dataset(upload_config, local_path)
         throw(JuliaHubError("Unknown upload type ($type) or vendor ($vendor)"))
     end
     mktemp() do rclone_conf_path, rclone_conf_io
-        Mocking.@mock _rclone() do rclone_exe  # This do block is unnecessary in 1.6
+        Mocking.@mock _rclone() do rclone_exe
             _write_rclone_config(rclone_conf_io, upload_config)
             close(rclone_conf_io)
 
@@ -979,5 +979,8 @@ function _assert_current_user(username::AbstractString, auth::Authentication; op
         throw(PermissionError("$op is only supported for the currently authenticated user"))
 end
 
-# Wrapping Rclone_jll.rclone here so that it could be mocked with Mockable
-_rclone(f::Function) = Rclone_jll.rclone(f)
+# Wrapping Rclone_jll.rclone here so that it could be mocked with Mocking.jl
+function _rclone(f::Function)
+    rclone_exe = Rclone_jll.rclone()
+    f(rclone_exe)
+end


### PR DESCRIPTION
The `do`-form got fully deprecated in https://github.com/JuliaPackaging/JLLWrappers.jl/commit/112e560b41c77f5ccd1f230dc1a9f271ea24d967. This is actually causing the live tests to fail, because it's now printing an extra warning that the tests are not accounting for: https://github.com/JuliaComputing/JuliaHub.jl/actions/runs/5883816382/job/15957283336#step:7:121