### PR TITLE
ci: run JuliaFormatter on all PRs

### DIFF
--- a/.github/workflows/julia_formatter.yml
+++ b/.github/workflows/julia_formatter.yml
@@ -3,10 +3,10 @@ on:
   push:
     branches:
       - main
-  pull_request:
     paths:
       - "**.jl"
       - ".JuliaFormatter.toml"
+  pull_request:
 
 env:
   CI: true


### PR DESCRIPTION
Because the formatter action is a required check for merging, it will block the merge when only excluded paths like CI and Markdown files are edited (happened in #16, #17). We _can_ filter on `paths` when in runs against master though.

