### PR TITLE
ci: disable live tests on fork PRs

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -50,6 +50,7 @@ jobs:
       - uses: julia-actions/julia-buildpkg@v1
       - uses: julia-actions/julia-runtest@v1
       - name: Run live tests
+        if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
         shell: julia --color=yes --project {0}
         run: |
           import Pkg


### PR DESCRIPTION
To avoid the CI failures seen in https://github.com/JuliaComputing/JuliaHub.jl/pull/26#issuecomment-1713952425

Note: this PR is from my personal fork. Here's also a version of this that runs on on "`main`", showing that the live tests do run if it's in this repo: https://github.com/JuliaComputing/JuliaHub.jl/tree/mp/fork-live-tests

Based on this answer: https://github.com/orgs/community/discussions/26829#discussioncomment-3253575