### PR TITLE
Mocked tests for app job submission, fix type instability

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## UNRELEASED
+
+### Fixed
+
+* Fixed the submission of application-type jobs. (#31, #32, #33)
+
 ## Version v0.1.4 - 2023-08-21
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 ### Fixed
 
 * Fixed the submission of application-type jobs. (#31, #32, #33)
+* `JuliaHub.applications()` no longer throws a type error when the user has no registered and user applications. (#33)
 
 ## Version v0.1.4 - 2023-08-21
 

--- a/src/applications.jl
+++ b/src/applications.jl
@@ -21,11 +21,13 @@ struct _RegistryInfo
     end
 end
 
-function _api_registries(auth::Authentication)
+function _api_registries(auth::Authentication)::Vector{_RegistryInfo}
     r = _restcall(auth, :GET, "app", "packages", "registries")
     json, _ = _parse_response_json(r, Dict)
     _json_check_success(json; var="app/packages/registries")
     registries = _json_get(json, "registries", Vector; var="app/packages/registries")
+    # Note: this broadcast can return Any[] if `registries` is empty, hence
+    # the need for a return type.
     return _RegistryInfo.(registries; var="app/packages/registries")
 end
 

--- a/test/applications.jl
+++ b/test/applications.jl
@@ -22,3 +22,19 @@ end
         @test JuliaHub.application(:default, "no-such-app"; throw=false) === nothing
     end
 end
+
+TEST_SUBMIT_APPS = [
+    (:default, "Pluto", JuliaHub.DefaultApp),
+    (:package, "RegisteredPackageApp", JuliaHub.PackageApp),
+    (:user, "ExampleApp.jl", JuliaHub.UserApp),
+]
+@testset "Submit app: :$cat / $apptype" for (cat, name, apptype) in TEST_SUBMIT_APPS
+    Mocking.apply(mocking_patch) do
+        app = JuliaHub.application(cat, name)
+        @test isa(app, apptype)
+        @test app.name == name
+        j = JuliaHub.submit_job(app)
+        @test j isa JuliaHub.Job
+        @test j.status == "Completed"
+    end
+end

--- a/test/applications.jl
+++ b/test/applications.jl
@@ -23,6 +23,19 @@ end
     end
 end
 
+@testset "Empty user/registered apps" begin
+    MOCK_JULIAHUB_STATE[:app_packages_registries] = []
+    MOCK_JULIAHUB_STATE[:app_applications_info] = []
+    MOCK_JULIAHUB_STATE[:app_applications_myapps] = []
+    Mocking.apply(mocking_patch) do
+        @test length(JuliaHub.applications()) == 4
+        @test length(JuliaHub.applications(:default)) == 4
+        @test length(JuliaHub.applications(:package)) == 0
+        @test length(JuliaHub.applications(:user)) == 0
+    end
+    empty!(MOCK_JULIAHUB_STATE)
+end
+
 TEST_SUBMIT_APPS = [
     (:default, "Pluto", JuliaHub.DefaultApp),
     (:package, "RegisteredPackageApp", JuliaHub.PackageApp),

--- a/test/mocking.jl
+++ b/test/mocking.jl
@@ -203,14 +203,16 @@ function _restcall_mocked(method, url, headers, payload; query)
             ],
         ) |> jsonresponse(200)
     elseif (method == :GET) && endswith(url, "app/packages/registries")
-        Dict(
-            "success" => true, "message" => "",
-            "registries" => [
+        packages_registries = get(MOCK_JULIAHUB_STATE, :app_packages_registries) do
+            [
                 #! format: off
                 Dict("name" => "General", "uuid" => "23338594-aafe-5451-b93e-139f81909106", "id" => 1),
                 Dict("name" => "JuliaComputingRegistry", "uuid" => "bbcd6645-47a4-41f8-a415-d8fc8421bd34", "id" => 266),
                 #! format: on
-            ],
+            ]
+        end
+        Dict(
+            "success" => true, "message" => "", "registries" => packages_registries
         ) |> jsonresponse(200)
     elseif (method == :GET) && endswith(url, "app/applications/default")
         r = if apiv >= v"0.0.1"
@@ -251,27 +253,33 @@ function _restcall_mocked(method, url, headers, payload; query)
         end
         r |> jsonresponse(200)
     elseif (method == :GET) && endswith(url, "app/applications/info")
-        Any[
-            Dict(
-                "name" => "RegisteredPackageApp",
-                "uuid" => "db8b4d46-bfad-4aa5-a5f8-40df1e9542e5",
-                "registrymap" => Any[Dict("status" => true, "id" => "1")],
-            ),
-            Dict(
-                "name" => "CustomDashboardApp",
-                "uuid" => "539b0f2a-a771-427e-a3ea-5fa1ee615c0c",
-                "registrymap" => Any[Dict("status" => true, "id" => "266")],
-            ),
-        ] |> jsonresponse(200)
+        applications_info = get(MOCK_JULIAHUB_STATE, :app_applications_info) do
+            Any[
+                Dict(
+                    "name" => "RegisteredPackageApp",
+                    "uuid" => "db8b4d46-bfad-4aa5-a5f8-40df1e9542e5",
+                    "registrymap" => Any[Dict("status" => true, "id" => "1")],
+                ),
+                Dict(
+                    "name" => "CustomDashboardApp",
+                    "uuid" => "539b0f2a-a771-427e-a3ea-5fa1ee615c0c",
+                    "registrymap" => Any[Dict("status" => true, "id" => "266")],
+                ),
+            ]
+        end
+        applications_info |> jsonresponse(200)
     elseif (method == :GET) && endswith(url, "app/applications/myapps")
-        #! format: off
-        Any[
-            Dict(
-                "name" => "ExampleApp.jl",
-                "repourl" => "https://github.com/JuliaHubExampleOrg/ExampleApp.jl",
-            ),
-        ] |> jsonresponse(200)
-        #! format: on
+        applications_myapps = get(MOCK_JULIAHUB_STATE, :app_applications_myapps) do
+            #! format: off
+            Any[
+                Dict(
+                    "name" => "ExampleApp.jl",
+                    "repourl" => "https://github.com/JuliaHubExampleOrg/ExampleApp.jl",
+                ),
+            ]
+            #! format: on
+        end
+        applications_myapps |> jsonresponse(200)
     elseif (method == :POST) && endswith(url, "juliaruncloud/submit_job")
         jobname = "jr-xf4tslavut"
         Dict("message" => "", "success" => true, "jobname" => jobname) |> jsonresponse(200)


### PR DESCRIPTION
Follows up on #31 and #32 with tests, but also fixes an error in `_api_registries`, where the function returns an `Any[]` and causes a method error down the line.