### PR TITLE
fix: submitting application jobs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 ### Fixed
 
-* Fixed the submission of application-type jobs. (#31, #32, #33)
+* Fixed the submission of application-type jobs. (#31, #32, #33, #35)
 * `JuliaHub.applications()` no longer throws a type error when the user has no registered and user applications. (#33)
 
 ## Version v0.1.4 - 2023-08-21

--- a/src/jobsubmission.jl
+++ b/src/jobsubmission.jl
@@ -3,6 +3,7 @@
 struct _JobSubmission1
     # User code & app configuration
     appType::Union{String, Nothing} # defaults to 'batch'
+    appArgs::Union{String, Nothing}
     args::String
     projectid::Union{String, Nothing}
     ## batch jobs
@@ -38,6 +39,7 @@ struct _JobSubmission1
     function _JobSubmission1(;
         # User code arguments
         appType::Union{AbstractString, Nothing}=nothing,
+        appArgs::Union{Dict, Nothing}=nothing,
         args::Dict,
         projectid::Union{String, Nothing},
         customcode::Bool, usercode::Union{AbstractString, Nothing}=nothing,
@@ -104,10 +106,11 @@ struct _JobSubmission1
             )
             appbundle_upload_info = JSON.json(appbundle_upload_info)
         end
+        appArgs = isnothing(appArgs) ? nothing : JSON.json(appArgs)
         # Create the _JobSubmission1 object
         new(
             # User code & app configuration
-            appType, args, projectid,
+            appType, appArgs, args, projectid,
             ## batch job configuration
             string(customcode),
             usercode,
@@ -1012,6 +1015,7 @@ function submit_job(
     else
         c.env
     end
+    merge!(args, get(app, :args, Dict()))
 
     projectid = isnothing(c.project) ? nothing : string(c.project)
 
@@ -1129,6 +1133,7 @@ function _job_submit_args(
 )
     return (;
         appType=appjob.app._apptype,
+        appArgs=Dict("authentication" => true, "authorization" => "me"),
         customcode=false,
         # `jr_uuid` is set to associate the running job with the application icon in the UI
         args=Dict("jobname" => appjob.app.name, "jr_uuid" => appjob.app._apptype),

--- a/src/jobsubmission.jl
+++ b/src/jobsubmission.jl
@@ -1015,7 +1015,7 @@ function submit_job(
     else
         c.env
     end
-    merge!(args, get(app, :args, Dict()))
+    args = merge(get(app, :args, Dict()), args)
 
     projectid = isnothing(c.project) ? nothing : string(c.project)
 

--- a/test/jobs-applications-live.jl
+++ b/test/jobs-applications-live.jl
@@ -1,0 +1,8 @@
+# The JULIAHUBJL_LIVE_IDE_NAME can be used to override the default Julia
+# IDE name, should it change in the backend.
+DEFAULT_IDE_NAME = get(ENV, "JULIAHUBJL_LIVE_IDE_NAME", "Julia IDE")
+
+@testset "[LIVE] Application job" begin
+    default_ide = JuliaHub.application(:default, DEFAULT_IDE_NAME)
+    JuliaHub.submit_job(default_ide)
+end

--- a/test/jobs-applications-live.jl
+++ b/test/jobs-applications-live.jl
@@ -4,8 +4,8 @@ DEFAULT_IDE_NAME = get(ENV, "JULIAHUBJL_LIVE_IDE_NAME", "Julia IDE")
 
 @testset "[LIVE] Application job" begin
     default_ide = JuliaHub.application(:default, DEFAULT_IDE_NAME)
-    job = JuliaHub.submit_job(default_ide)
-    @test job.alias == DEFAULT_IDE_NAME
+    job, _ = submit_test_job(default_ide, auth; alias=DEFAULT_IDE_NAME)
+    @test occursin(DEFAULT_IDE_NAME, job.alias)
     job = wait_submission(job)
     @test job.status == "Running"
     job = JuliaHub.kill_job(job)

--- a/test/jobs-applications-live.jl
+++ b/test/jobs-applications-live.jl
@@ -4,5 +4,11 @@ DEFAULT_IDE_NAME = get(ENV, "JULIAHUBJL_LIVE_IDE_NAME", "Julia IDE")
 
 @testset "[LIVE] Application job" begin
     default_ide = JuliaHub.application(:default, DEFAULT_IDE_NAME)
-    JuliaHub.submit_job(default_ide)
+    job = JuliaHub.submit_job(default_ide)
+    @test job.alias == DEFAULT_IDE_NAME
+    job = wait_submission(job)
+    @test job.status == "Running"
+    job = JuliaHub.kill_job(job)
+    job = JuliaHub.wait_job(job)
+    @test job.status == "Stopped"
 end

--- a/test/jobs-applications-live.jl
+++ b/test/jobs-applications-live.jl
@@ -4,7 +4,7 @@ DEFAULT_IDE_NAME = get(ENV, "JULIAHUBJL_LIVE_IDE_NAME", "Julia IDE")
 
 @testset "[LIVE] Application job" begin
     default_ide = JuliaHub.application(:default, DEFAULT_IDE_NAME)
-    job, _ = submit_test_job(default_ide, auth; alias=DEFAULT_IDE_NAME)
+    job, _ = submit_test_job(default_ide; auth, alias=DEFAULT_IDE_NAME)
     @test occursin(DEFAULT_IDE_NAME, job.alias)
     job = wait_submission(job)
     @test job.status == "Running"

--- a/test/runtests-live.jl
+++ b/test/runtests-live.jl
@@ -56,6 +56,11 @@ JuliaHub.__AUTH__[] = auth
             include("jobs-live.jl")
         end
 
+    is_enabled("jobs-applications") &&
+        @testset "JuliaHub Apps" begin
+            include("jobs-applications-live.jl")
+        end
+
     is_enabled("jobs-windows") &&
         @testset "JuliaHub Jobs" begin
             include("jobs-windows-live.jl")


### PR DESCRIPTION
Applications require `appArgs` to be set. Also adds a live test that attempts to submit, start, and then stop a `JuliaHub IDE` job.