### PR TITLE
ci: run CI on a weekly schedule

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -6,6 +6,8 @@ on:
       - main
     tags: ["*"]
   pull_request:
+  schedule:
+    - cron: '0 0 * * 1' # runs 00:00 UTC on every Monday
 
 concurrency:
   # Skip intermediate builds: always.


### PR DESCRIPTION
This repo does not see daily activity, but it would be good to know early if something has started failing the tests (the live tests in particular).