### PR TITLE
fix: handle backend responses more gracefully in datasets requests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## Version v0.1.7 - 2024-01-15
+## Version v0.1.7 - 2024-01-18
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 ### Fixed
 
-* `JuliaHub.datasets` and `JuliaHub.dataset` now handle problematic backend responses more gracefully. (#??)
+* `JuliaHub.datasets` and `JuliaHub.dataset` now handle problematic backend responses more gracefully. (#46)
 
 ## Version v0.1.6 - 2023-11-27
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,11 +2,17 @@
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## Version v0.1.7 - 2024-01-15
+
+### Fixed
+
+* `JuliaHub.datasets` and `JuliaHub.dataset` now handle problematic backend responses more gracefully. (#??)
+
 ## Version v0.1.6 - 2023-11-27
 
 ### Fixed
 
-* `JuliaHub.appbundle`, when it has to generate a `Projec.toml` file, now correctly includes it in the appbundle tarball. (#44)
+* `JuliaHub.appbundle`, when it has to generate a `Project.toml` file, now correctly includes it in the appbundle tarball. (#44)
 * `JuliaHub.appbundle` now works with relative paths such as `"."`. (#44)
 
 ## Version v0.1.5 - 2023-09-27

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "JuliaHub"
 uuid = "bc7fa6ce-b75e-4d60-89ad-56c957190b6e"
 authors = ["JuliaHub Inc."]
-version = "0.1.6"
+version = "0.1.7"
 
 [deps]
 Base64 = "2a0f44e3-6c83-55bd-87e4-b1978d98bd5f"

--- a/src/datasets.jl
+++ b/src/datasets.jl
@@ -345,7 +345,7 @@ function datasets(
         end
     end
     if n_erroneous_datasets > 0
-        @warn "The JuliaHub GET /datasets response had $(n_erroneous_datasets) erroneous dataset(s)."
+        @warn "The JuliaHub GET /datasets response contains erroneous dataset(s). Omitting $(n_erroneous_datasets) entries."
     end
     # We'll filter down to just Dataset objects, and enforce type-stability on the array type here.
     return Dataset[ds for ds in datasets if isa(ds, Dataset)]

--- a/src/datasets.jl
+++ b/src/datasets.jl
@@ -344,7 +344,6 @@ function datasets(
             return nothing
         end
     end
-    @show n_erroneous_datasets
     if n_erroneous_datasets > 0
         @warn "The JuliaHub GET /datasets response had $(n_erroneous_datasets) erroneous dataset(s)."
     end

--- a/src/datasets.jl
+++ b/src/datasets.jl
@@ -345,7 +345,7 @@ function datasets(
         end
     end
     if n_erroneous_datasets > 0
-        @warn "The JuliaHub GET /datasets response contains erroneous dataset(s). Omitting $(n_erroneous_datasets) entries."
+        @warn "The JuliaHub GET /datasets response contains erroneous datasets. Omitting $(n_erroneous_datasets) entries."
     end
     # We'll filter down to just Dataset objects, and enforce type-stability on the array type here.
     return Dataset[ds for ds in datasets if isa(ds, Dataset)]

--- a/src/datasets.jl
+++ b/src/datasets.jl
@@ -340,7 +340,7 @@ function datasets(
             @debug "Invalid dataset in GET /datasets response" dataset exception = (
                 e, catch_backtrace()
             )
-            n_erroneous_datasets += true
+            n_erroneous_datasets += 1
             return nothing
         end
     end

--- a/test/datasets-live.jl
+++ b/test/datasets-live.jl
@@ -83,7 +83,7 @@ try
     JuliaHub.upload_dataset(
         (auth.username, blobname), joinpath(TESTDATA, "hi.txt"); create=false, update=true
     )
-    datasets, _ = JuliaHub._get_datasets(; auth)
+    datasets, _ = JuliaHub._get_datasets(auth)
     blob_dataset_json = only(filter(d -> d["name"] == blobname, datasets))
     @test length(blob_dataset_json["versions"]) == 2
 
@@ -100,7 +100,7 @@ try
     @test tree_dataset.dtype == "BlobTree"
 
     JuliaHub.upload_dataset(treename, TESTDATA; auth, create=false, update=true)
-    datasets, _ = JuliaHub._get_datasets(; auth)
+    datasets, _ = JuliaHub._get_datasets(auth)
     tree_dataset_json = only(filter(d -> d["name"] == treename, datasets))
     @test length(tree_dataset_json["versions"]) == 2
 

--- a/test/datasets.jl
+++ b/test/datasets.jl
@@ -106,7 +106,10 @@ end
         end
 
         MOCK_JULIAHUB_STATE[:datasets_erroneous] = ["erroneous_dataset"]
-        err_ds_warn = (:warn, "The JuliaHub GET /datasets response contains erroneous datasets. Omitting 1 entries.")
+        err_ds_warn = (
+            :warn,
+            "The JuliaHub GET /datasets response contains erroneous datasets. Omitting 1 entries.",
+        )
         let datasets = @test_nowarn JuliaHub.datasets()
             @test length(datasets) == 2
         end

--- a/test/datasets.jl
+++ b/test/datasets.jl
@@ -105,32 +105,25 @@ end
             @test isempty(ds.versions)
         end
 
-        empty!(MOCK_JULIAHUB_STATE)
         MOCK_JULIAHUB_STATE[:datasets_erroneous] = ["erroneous_dataset"]
+        err_ds_warn = (:warn, "The JuliaHub GET /datasets response had 1 erroneous dataset(s).")
         let datasets = @test_nowarn JuliaHub.datasets()
             @test length(datasets) == 2
         end
-        let datasets = @test_logs (
-                :warn,
-                "The JuliaHub GET /datasets response had 1 erroneous dataset(s)."
-            ) JuliaHub.datasets(; shared=true)
+        let datasets = @test_logs err_ds_warn JuliaHub.datasets(; shared=true)
             @test length(datasets) == 3
         end
-        let ds = @test_logs (
-                :warn,
-                "The JuliaHub GET /datasets response had 1 erroneous dataset(s)."
-            ) JuliaHub.dataset("example-dataset")
+        let ds = @test_logs err_ds_warn JuliaHub.dataset("example-dataset")
             @test ds isa JuliaHub.Dataset
         end
-        let ds = @test_logs (
-                :warn,
-                "The JuliaHub GET /datasets response had 1 erroneous dataset(s)."
-            ) JuliaHub.dataset("example-dataset")
+        let ds = @test_logs err_ds_warn JuliaHub.dataset("example-dataset")
             @test ds isa JuliaHub.Dataset
             @test ds.owner == "username"
             @test ds.name == "example-dataset"
         end
-        @test_throws JuliaHub.InvalidRequestError JuliaHub.dataset("erroneous_dataset")
+        @test_logs err_ds_warn begin
+            @test_throws JuliaHub.InvalidRequestError JuliaHub.dataset("erroneous_dataset")
+        end
     end
 end
 

--- a/test/datasets.jl
+++ b/test/datasets.jl
@@ -106,7 +106,7 @@ end
         end
 
         MOCK_JULIAHUB_STATE[:datasets_erroneous] = ["erroneous_dataset"]
-        err_ds_warn = (:warn, "The JuliaHub GET /datasets response had 1 erroneous dataset(s).")
+        err_ds_warn = (:warn, "The JuliaHub GET /datasets response contains erroneous datasets. Omitting 1 entries.")
         let datasets = @test_nowarn JuliaHub.datasets()
             @test length(datasets) == 2
         end

--- a/test/datasets.jl
+++ b/test/datasets.jl
@@ -104,6 +104,33 @@ end
             @test ds.description == "An example dataset"
             @test isempty(ds.versions)
         end
+
+        empty!(MOCK_JULIAHUB_STATE)
+        MOCK_JULIAHUB_STATE[:datasets_erroneous] = ["erroneous_dataset"]
+        let datasets = @test_nowarn JuliaHub.datasets()
+            @test length(datasets) == 2
+        end
+        let datasets = @test_logs (
+                :warn,
+                "The JuliaHub GET /datasets response had 1 erroneous dataset(s)."
+            ) JuliaHub.datasets(; shared=true)
+            @test length(datasets) == 3
+        end
+        let ds = @test_logs (
+                :warn,
+                "The JuliaHub GET /datasets response had 1 erroneous dataset(s)."
+            ) JuliaHub.dataset("example-dataset")
+            @test ds isa JuliaHub.Dataset
+        end
+        let ds = @test_logs (
+                :warn,
+                "The JuliaHub GET /datasets response had 1 erroneous dataset(s)."
+            ) JuliaHub.dataset("example-dataset")
+            @test ds isa JuliaHub.Dataset
+            @test ds.owner == "username"
+            @test ds.name == "example-dataset"
+        end
+        @test_throws JuliaHub.InvalidRequestError JuliaHub.dataset("erroneous_dataset")
     end
 end
 

--- a/test/mocking.jl
+++ b/test/mocking.jl
@@ -384,6 +384,22 @@ function _restcall_mocked(method, url, headers, payload; query)
                 ),
             )
         end
+        for dataset in get(MOCK_JULIAHUB_STATE, :datasets_erroneous, String[])
+            push!(datasets,
+                Dict(
+                    "id" => string(uuidhash(dataset)),
+                    "name" => dataset,
+                    "owner" => Dict(
+                        "username" => nothing,
+                        "type" => "User",
+                    ),
+                    "type" => occursin("blobtree", dataset) ? "BlobTree" : "Blob",
+                    "visibility" => occursin("public", dataset) ? "public" : "private",
+                    versions_json(dataset)...,
+                    shared...,
+                ),
+            )
+        end
         datasets |> jsonresponse(200)
     elseif (method == :DELETE) && endswith(url, DATASET_REGEX)
         dataset = URIs.unescapeuri(match(DATASET_REGEX, url)[1])


### PR DESCRIPTION
Handles problematic dataset list backend responses more gracefully, by printing one warning per call, rather than throwing an error.

Also, unrelated to the main change, but makes the `auth` argument of the internal `_get_datasets` function positional, for consistency.