### PR TITLE
test: ensure consistent Julia environments in live job tests

### DIFF
--- a/test/jobenvs/job-dist/Manifest.toml
+++ b/test/jobenvs/job-dist/Manifest.toml
@@ -2,24 +2,15 @@
 
 julia_version = "1.9.4"
 manifest_format = "2.0"
-project_hash = "19ff69f495991858cf34afc4927fe003524460ea"
-
-[[deps.Base64]]
-uuid = "2a0f44e3-6c83-55bd-87e4-b1978d98bd5f"
-
-[[deps.DataStructures]]
-deps = ["InteractiveUtils", "OrderedCollections"]
-git-tree-sha1 = "88d48e133e6d3dd68183309877eac74393daa7eb"
-uuid = "864edb3b-99cc-5e75-8d2d-829cb0a9cfe8"
-version = "0.17.20"
+project_hash = "15b8400de0ed6d0aa5f96c6341a036f45951aee0"
 
 [[deps.Dates]]
 deps = ["Printf"]
 uuid = "ade2ca70-3891-5945-98fb-dc099432e06a"
 
-[[deps.InteractiveUtils]]
-deps = ["Markdown"]
-uuid = "b77e0a4c-d291-57a0-90e8-8db25a27a240"
+[[deps.Distributed]]
+deps = ["Random", "Serialization", "Sockets"]
+uuid = "8ba89e20-285c-5b6f-9357-94700520ee1b"
 
 [[deps.JSON]]
 deps = ["Dates", "Mmap", "Parsers", "Unicode"]
@@ -27,17 +18,8 @@ git-tree-sha1 = "31e996f0a15c7b280ba9f76636b3ff9e2ae58c9a"
 uuid = "682c06a0-de6a-54ab-a142-c8b1cf79cde6"
 version = "0.21.4"
 
-[[deps.Markdown]]
-deps = ["Base64"]
-uuid = "d6f4376e-aef5-505a-96c1-9c027394607a"
-
 [[deps.Mmap]]
 uuid = "a63ad114-7e13-5084-954f-fe012c677804"
-
-[[deps.OrderedCollections]]
-git-tree-sha1 = "dfdf5519f235516220579f949664f1bf44e741c5"
-uuid = "bac558e1-5e72-5ebc-8fee-abe8a469f55d"
-version = "1.6.3"
 
 [[deps.Parsers]]
 deps = ["Dates", "PrecompileTools", "UUIDs"]
@@ -71,6 +53,9 @@ version = "0.7.0"
 
 [[deps.Serialization]]
 uuid = "9e88b42a-f829-5b0c-bbe9-9e923198166b"
+
+[[deps.Sockets]]
+uuid = "6462fe0b-24de-5631-8697-dd941f90decc"
 
 [[deps.TOML]]
 deps = ["Dates"]

--- a/test/jobenvs/job-dist/Project.toml
+++ b/test/jobenvs/job-dist/Project.toml
@@ -1,0 +1,3 @@
+[deps]
+Distributed = "8ba89e20-285c-5b6f-9357-94700520ee1b"
+JSON = "682c06a0-de6a-54ab-a142-c8b1cf79cde6"

--- a/test/jobenvs/job-dist/script.jl
+++ b/test/jobenvs/job-dist/script.jl
@@ -1,0 +1,10 @@
+using Distributed, JSON
+@everywhere using Distributed
+@everywhere fn() = (myid(), strip(read(`hostname`, String)))
+fs = [i => remotecall(fn, i) for i in workers()]
+vs = map(fs) do (i, future)
+    myid, hostname = fetch(future)
+    @info "$i: $myid, $hostname"
+    (; myid, hostname)
+end
+ENV["RESULTS"] = JSON.json((; vs))

--- a/test/jobenvs/job1/Manifest.toml
+++ b/test/jobenvs/job1/Manifest.toml
@@ -2,7 +2,7 @@
 
 julia_version = "1.9.4"
 manifest_format = "2.0"
-project_hash = "1dac4d10ee824406f2fc3bc68875d2fef6ca62ff"
+project_hash = "19ff69f495991858cf34afc4927fe003524460ea"
 
 [[deps.Base64]]
 uuid = "2a0f44e3-6c83-55bd-87e4-b1978d98bd5f"

--- a/test/jobenvs/job1/Manifest.toml
+++ b/test/jobenvs/job1/Manifest.toml
@@ -2,16 +2,16 @@
 
 julia_version = "1.9.4"
 manifest_format = "2.0"
-project_hash = "19ff69f495991858cf34afc4927fe003524460ea"
+project_hash = "1dac4d10ee824406f2fc3bc68875d2fef6ca62ff"
 
 [[deps.Base64]]
 uuid = "2a0f44e3-6c83-55bd-87e4-b1978d98bd5f"
 
 [[deps.DataStructures]]
 deps = ["InteractiveUtils", "OrderedCollections"]
-git-tree-sha1 = "88d48e133e6d3dd68183309877eac74393daa7eb"
+git-tree-sha1 = "0809951a1774dc724da22d26e4289bbaab77809a"
 uuid = "864edb3b-99cc-5e75-8d2d-829cb0a9cfe8"
-version = "0.17.20"
+version = "0.17.0"
 
 [[deps.Dates]]
 deps = ["Printf"]

--- a/test/jobenvs/job1/Project.toml
+++ b/test/jobenvs/job1/Project.toml
@@ -3,5 +3,7 @@ DataStructures = "864edb3b-99cc-5e75-8d2d-829cb0a9cfe8"
 JSON = "682c06a0-de6a-54ab-a142-c8b1cf79cde6"
 
 [compat]
-DataStructures = "=0.17.0"
+# Note: this should be resolved to exactly 0.17.0 in Manifest.toml
+# for the tests to pass.
+DataStructures = "0.17.0"
 JSON = "0.21"

--- a/test/jobenvs/job1/Project.toml
+++ b/test/jobenvs/job1/Project.toml
@@ -3,5 +3,5 @@ DataStructures = "864edb3b-99cc-5e75-8d2d-829cb0a9cfe8"
 JSON = "682c06a0-de6a-54ab-a142-c8b1cf79cde6"
 
 [compat]
-DataStructures = "0.17"
+DataStructures = "=0.17.0"
 JSON = "0.21"

--- a/test/jobs-live.jl
+++ b/test/jobs-live.jl
@@ -293,6 +293,11 @@ end
     )
     job = JuliaHub.wait_job(job)
     @test job.status == "Completed"
+    # Check input and output files
+    @test length(JuliaHub.job_files(job, :input)) >= 2
+    @test JuliaHub.job_file(job, :input, "code.jl") isa JuliaHub.JobFile
+    @test JuliaHub.job_file(job, :input, "appbundle.tar") isa JuliaHub.JobFile
+    # Test the results values
     @test !isempty(job.results)
     let results = JSON.parse(job.results)
         @test results isa AbstractDict
@@ -315,16 +320,13 @@ end
     job = JuliaHub.wait_job(job)
     @test job.status == "Completed"
     # Project.toml, Manifest.toml, code.jl
-    @test length(JuliaHub.job_files(job, :input)) >= 3
-    @test JuliaHub.job_file(job, :input, "Project.toml") isa JuliaHub.JobFile
-    @test JuliaHub.job_file(job, :input, "Manifest.toml") isa JuliaHub.JobFile
+    @test length(JuliaHub.job_files(job, :input)) >= 1
     @test JuliaHub.job_file(job, :input, "code.jl") isa JuliaHub.JobFile
     # code.jl
     @test length(JuliaHub.job_files(job, :source)) >= 1
     @test JuliaHub.job_file(job, :source, "code.jl") isa JuliaHub.JobFile
     # Project.toml, Manifest.toml
-    @test length(JuliaHub.job_files(job, :project)) >= 2
-    @test JuliaHub.job_file(job, :project, "Project.toml") isa JuliaHub.JobFile
+    @test length(JuliaHub.job_files(job, :project)) >= 1
     @test JuliaHub.job_file(job, :project, "Manifest.toml") isa JuliaHub.JobFile
     # output.txt
     @test length(JuliaHub.job_files(job, :result)) == 1
@@ -347,7 +349,7 @@ end
     )
     job = JuliaHub.wait_job(job)
     @test job.status == "Completed"
-    @test length(JuliaHub.job_files(job, :project)) >= 2
+    @test length(JuliaHub.job_files(job, :project)) >= 1
     result_tarball = only(JuliaHub.job_files(job, :result))
     buf = IOBuffer()
     JuliaHub.download_job_file(result_tarball, buf)

--- a/test/jobs-live.jl
+++ b/test/jobs-live.jl
@@ -116,7 +116,7 @@ end
 
 @testset "[LIVE] JuliaHub.submit_job / simple" begin
     job, _ = submit_test_job(
-        JuliaHub.script"@info 1+1; sleep(200)";
+        JuliaHub.script"@info 1+1; sleep(200)"noenv;
         ncpu=2, memory=8,
         auth, alias="script-simple"
     )
@@ -310,7 +310,7 @@ end
         ENV["RESULTS_FILE"] = joinpath(@__DIR__, "output.txt")
         n = write(ENV["RESULTS_FILE"], "output-txt-content")
         @info "Wrote $(n) bytes"
-        """; alias="output-file",
+        """noenv; alias="output-file",
     )
     job = JuliaHub.wait_job(job)
     @test job.status == "Completed"
@@ -343,7 +343,7 @@ end
         write(joinpath(odir, "bar.txt"), "output-txt-content-2")
         @info "Wrote: odir"
         ENV["RESULTS_FILE"] = odir
-        """; alias="output-file-tarball",
+        """noenv; alias="output-file-tarball",
     )
     job = JuliaHub.wait_job(job)
     @test job.status == "Completed"

--- a/test/jobs.jl
+++ b/test/jobs.jl
@@ -96,7 +96,7 @@ end
     @test isfile(bundle.environment.tarball_path)
     @test bundle.code == "test()"
     @test bundle.sysimage === true
-    @test JuliaHub._sysimage_manifest_sha(bundle.environment) == "7030454c118028ff8ae5db7ca01625f38c95f82322a949ba2f55dd33f5c1568e"
+    @test JuliaHub._sysimage_manifest_sha(bundle.environment) == "c9f7e46452d155342140ed8761cba4b8667a1fc151f97c72c163f1a9d24d7e44"
 
     mktempdir() do path
         bigfile_path = joinpath(path, "bigfile")

--- a/test/jobs.jl
+++ b/test/jobs.jl
@@ -96,7 +96,7 @@ end
     @test isfile(bundle.environment.tarball_path)
     @test bundle.code == "test()"
     @test bundle.sysimage === true
-    @test JuliaHub._sysimage_manifest_sha(bundle.environment) == "c9f7e46452d155342140ed8761cba4b8667a1fc151f97c72c163f1a9d24d7e44"
+    @test JuliaHub._sysimage_manifest_sha(bundle.environment) == "631fc619c1d04e525872df2779fa95a0dc47edd9558af629af88c493daa6300d"
 
     mktempdir() do path
         bigfile_path = joinpath(path, "bigfile")

--- a/test/jobs.jl
+++ b/test/jobs.jl
@@ -96,7 +96,7 @@ end
     @test isfile(bundle.environment.tarball_path)
     @test bundle.code == "test()"
     @test bundle.sysimage === true
-    @test JuliaHub._sysimage_manifest_sha(bundle.environment) == "e066dbebe85bb0a0ed79356a81ddc2223974f784cea3f512cea615a2d5731b0e"
+    @test JuliaHub._sysimage_manifest_sha(bundle.environment) == "7030454c118028ff8ae5db7ca01625f38c95f82322a949ba2f55dd33f5c1568e"
 
     mktempdir() do path
         bigfile_path = joinpath(path, "bigfile")


### PR DESCRIPTION
JuliaHub jobs have a fixed Julia version (1.9 presently), so you need to make sure you submit a `Manifest.toml` that is compatible with it. However, the current live tests sometimes resolve things with the running Julia version, and we run the tests with a whole range of Julia versions. With nightly Julia builds, this now causes issues (specifically, the `StyledStrings` standard library is not available on older Julia versions).

* Use `script""noenv` for all the tests that submit simple scripts. Standard `script""` attaches the currently running environment, which may declare dependencies that are not valid when running with a different Julia version. Those tests don't require any packages.
* Turn the distributed tests into an appbundle with a pre-resolved environment.
* Update the `job1` manifest to 1.9.