### PR TITLE
chore: fix Julia formatting

### DIFF
--- a/docs/make.jl
+++ b/docs/make.jl
@@ -64,7 +64,7 @@ Mocking.apply(mocking_patch) do
         authors="JuliaHub Inc.",
         format=Documenter.HTML(;
             canonical="https://help.juliahub.com/julia-api/stable",
-            edit_link="main"
+            edit_link="main",
         ),
         pages=[
             "Home" => "index.md",

--- a/src/authentication.jl
+++ b/src/authentication.jl
@@ -202,7 +202,7 @@ function authenticate(
     server_uri_string = if isnothing(server)
         haskey(ENV, "JULIA_PKG_SERVER") || throw(
             AuthenticationError(
-                "Either JULIA_PKG_SERVER must be set, or explicit `server` argument passed to JuliaHub.authenticate().",
+                "Either JULIA_PKG_SERVER must be set, or explicit `server` argument passed to JuliaHub.authenticate()."
             ),
         )
         Pkg.pkg_server()
@@ -442,7 +442,7 @@ function reauthenticate!(
     if new_auth.username != auth.username
         throw(
             AuthenticationError(
-                "Username in new authentication ($(new_auth.username)) does not match original authentication ($(auth.username))",
+                "Username in new authentication ($(new_auth.username)) does not match original authentication ($(auth.username))"
             ),
         )
     end

--- a/src/datasets.jl
+++ b/src/datasets.jl
@@ -317,7 +317,7 @@ function datasets(
         e isa JuliaHubException && rethrow(e)
         e isa JuliaHubError && rethrow(e)
         throw(
-            JuliaHubError("Error while retrieving datasets from the server", e, catch_backtrace()),
+            JuliaHubError("Error while retrieving datasets from the server", e, catch_backtrace())
         )
     end
     # It might happen that some of the elements of the `datasets` array can not be parsed for some reason,
@@ -406,7 +406,7 @@ function dataset end
 @_authuser function dataset(
     dsref::_DatasetRefTuple;
     throw::Bool=true,
-    auth::Authentication=__auth__()
+    auth::Authentication=__auth__(),
 )
     username, dataset_name = dsref
     for dataset in datasets(; shared=true, auth)
@@ -447,7 +447,7 @@ function delete_dataset end
 @_authuser function delete_dataset(
     dsref::_DatasetRefTuple;
     force::Bool=false,
-    auth::Authentication=__auth__()
+    auth::Authentication=__auth__(),
 )
     username, dataset_name = dsref
     _assert_current_user(username, auth; op="delete_dataset")
@@ -548,7 +548,7 @@ function upload_dataset end
                 # we must throw an invalid request error.
                 throw(
                     InvalidRequestError(
-                        "Dataset '$dataset_name' for user '$username' already exists, but update=false and replace=false.",
+                        "Dataset '$dataset_name' for user '$username' already exists, but update=false and replace=false."
                     ),
                 )
             elseif replace
@@ -600,7 +600,7 @@ function upload_dataset end
             # dtype).
             throw(
                 InvalidRequestError(
-                    "Local data type ($dtype) does not match existing dataset dtype $(upload_config["dataset_type"])",
+                    "Local data type ($dtype) does not match existing dataset dtype $(upload_config["dataset_type"])"
                 ),
             )
         end
@@ -622,7 +622,7 @@ function upload_dataset end
     if !all(ismissing.((description, tags, visibility, license, groups)))
         update_dataset(
             (username, dataset_name); auth,
-            description, tags, visibility, license, groups
+            description, tags, visibility, license, groups,
         )
     end
     # If everything was successful, we'll return an updated DataSet object.
@@ -843,7 +843,7 @@ function download_dataset(
     dsref::_DatasetRefTuple,
     local_path::AbstractString;
     auth::Authentication=__auth__(),
-    kwargs...
+    kwargs...,
 )
     ds = dataset(dsref; auth)
     download_dataset(ds, local_path; auth, kwargs...)
@@ -858,7 +858,7 @@ function download_dataset(
 )
     dataset.dtype ∈ ["Blob", "BlobTree"] || throw(
         InvalidRequestError(
-            "Download only supported for Blobs and BlobTrees, but '$(dataset.name)' is $(dataset.type)",
+            "Download only supported for Blobs and BlobTrees, but '$(dataset.name)' is $(dataset.type)"
         ),
     )
 

--- a/src/jobs/jobs.jl
+++ b/src/jobs/jobs.jl
@@ -511,7 +511,7 @@ function _download_job_file(auth::Authentication, file::JobFile, io::IO)
         job_file_url,
         _authheaders(auth);
         status_exception=false,
-        response_stream=io
+        response_stream=io,
     )
     r.status == 200 || _throw_invalidresponse(r)
     return nothing

--- a/src/jobs/logging-kafka.jl
+++ b/src/jobs/logging-kafka.jl
@@ -71,7 +71,7 @@ mutable struct KafkaLogsBuffer <: AbstractJobLogsBuffer
             f,
             nothing,
             0,
-            ReentrantLock()
+            ReentrantLock(),
         )
         # If the user requested streaming too, then we start the background task.
         stream && _job_logs_kafka_start_streaming!(auth, b)
@@ -142,7 +142,7 @@ function _job_logs_newer!(
     consumer_id, logs, job_is_done = _get_logs_kafka_parsed(
         auth, jobname;
         offset=_kafka_next_offset(b),
-        timeout=_KAFKA_DEFAULT_GET_TIMEOUT
+        timeout=_KAFKA_DEFAULT_GET_TIMEOUT,
     )
     job_is_done && (b._found_last = true)
     # If the returned list of logs is empty, we check if we can still update the cursor
@@ -176,7 +176,7 @@ function _job_logs_newer!(
         next_offset = last(logs)._offset + 1
         consumer_id, logs, job_is_done = _get_logs_kafka_parsed(
             auth, jobname; offset=next_offset, consumer_id,
-            timeout=_KAFKA_DEFAULT_GET_TIMEOUT
+            timeout=_KAFKA_DEFAULT_GET_TIMEOUT,
         )
         job_is_done && (b._found_last = true)
     end
@@ -257,7 +257,7 @@ function _job_logs_older!(
     consumer_id, logs, _ = _get_logs_kafka_parsed(
         auth, jobname;
         offset=next_offset,
-        timeout=_KAFKA_DEFAULT_GET_TIMEOUT
+        timeout=_KAFKA_DEFAULT_GET_TIMEOUT,
     )
     # This should not normally happen because we should only be asking for logs that are actually present.
     # But sometimes it does.. maybe when the timeout is not long enough? So we handle this by gracefully
@@ -278,7 +278,7 @@ function _job_logs_older!(
         next_offset = last(logs)._offset + 1
         consumer_id, logs, _ = _get_logs_kafka_parsed(
             auth, jobname; offset=next_offset, consumer_id,
-            timeout=_KAFKA_DEFAULT_GET_TIMEOUT
+            timeout=_KAFKA_DEFAULT_GET_TIMEOUT,
         )
         @assert !isempty(logs)
     end

--- a/src/jobs/logging-legacy.jl
+++ b/src/jobs/logging-legacy.jl
@@ -188,7 +188,7 @@ function _get_job_logs_legacy(
     query = Pair{String, Any}[
         "log_output_type" => "content",
         "jobname" => jobname,
-        "log_out_type" => "json"
+        "log_out_type" => "json",
     ]
     if start_time !== nothing
         if end_time !== nothing
@@ -224,7 +224,7 @@ function _get_job_logs_legacy(
     if jb isa Dict && !get(jb, "success", true)
         throw(
             JuliaHubError(
-                "Downloading log content failed: `$(get(jb, "reason", get(jb, "message", "unknown error")))`",
+                "Downloading log content failed: `$(get(jb, "reason", get(jb, "message", "unknown error")))`"
             ),
         )
     end
@@ -461,7 +461,7 @@ function _job_logs_older!(
         r = JuliaHub._get_job_logs_legacy(
             auth, jobname;
             end_time=timestamp,
-            event_id=reference_log._legacy_eventId
+            event_id=reference_log._legacy_eventId,
         )
         if isempty(r.logs)
             # TODO: If the logs are empty, then something has probably gone wrong

--- a/src/jobs/logging.jl
+++ b/src/jobs/logging.jl
@@ -64,7 +64,7 @@ end
 _print_log_list(logs::Vector{JobLogMessage}; kwargs...) = _print_log_list(stdout, logs; kwargs...)
 function _print_log_list(
     io::IO, logs::Vector{JobLogMessage}; all::Bool=false,
-    nlines::Integer=_default_display_lines(io)
+    nlines::Integer=_default_display_lines(io),
 )
     @assert Base.all(x -> isa(x, JobLogMessage), logs) # note: kwarg shadows function
     @assert nlines >= 1

--- a/src/jobsubmission.jl
+++ b/src/jobsubmission.jl
@@ -785,7 +785,7 @@ function _upload_appbundle(appbundle_tar_path::AbstractString; auth::Authenticat
         Mocking.@mock _restput_mockable(
             upload_url,
             ["Content-Length" => filesize(appbundle_tar_path)],
-            input
+            input,
         )
     end
     # The response body of a successful upload is empty
@@ -1136,7 +1136,7 @@ function submit_job(
     end
     submit_job(
         WorkloadConfig(app, compute; alias, env, project, timelimit, _image_sha256);
-        kwargs...
+        kwargs...,
     )
 end
 
@@ -1290,7 +1290,7 @@ function _job_submit_args(
         registry_name=packagejob.registry,
         args=merge(
             Dict("jobname" => packagejob.name, "jr_uuid" => packagejob.jr_uuid),
-            packagejob.args
+            packagejob.args,
         ),
         # Just in case, we want to omit sysimage_build altogether when it is not requested.
         sysimage_build=packagejob.sysimage ? true : nothing,

--- a/src/node.jl
+++ b/src/node.jl
@@ -170,7 +170,7 @@ function _nodespec_exact(
     if isempty(idxs)
         return _throw_or_nothing(;
             msg="Unable to find a nodespec: ncpu=$ncpu memory=$memory gpu=$gpu",
-            throw
+            throw,
         )
     end
     if length(idxs) > 1
@@ -192,7 +192,7 @@ function _nodespec_smallest(
     if isnothing(idx)
         return _throw_or_nothing(;
             msg="Unable to find a nodespec with at least: ncpu=$ncpu memory=$memory gpu=$gpu",
-            throw
+            throw,
         )
     else
         return nodes[idx]

--- a/src/userinfo.jl
+++ b/src/userinfo.jl
@@ -44,7 +44,7 @@ function _get_authenticated_user_legacy(server::AbstractString, token::Secret)::
     json, _ = _parse_response_json(r, Dict)
     users = _get_json(_get_json(json, "data", Dict; msg), "users", Vector)
     length(users) == 1 || throw(
-        JuliaHubError("$msg\nInvalid JSON returned by the server: length(users)=$(length(users))"),
+        JuliaHubError("$msg\nInvalid JSON returned by the server: length(users)=$(length(users))")
     )
     user = only(users)
     userid = _get_json(user, "id", Int; msg)

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -140,7 +140,7 @@ function _parse_response_json(s::AbstractString, ::Type{T})::Tuple{T, String} wh
     if !isa(object, T)
         throw(
             JuliaHubError(
-                "Invalid JSON returned by the server (expected `$T`, got `$(typeof(object))`):\n$(s)",
+                "Invalid JSON returned by the server (expected `$T`, got `$(typeof(object))`):\n$(s)"
             ),
         )
     end
@@ -368,7 +368,7 @@ _nothing_or(f::Base.Callable, x) = isnothing(x) ? nothing : f(x)
 function _throw_or_nothing(
     nothrow_extra_logic_f::Union{Base.Callable, Nothing}=nothing;
     msg::AbstractString,
-    throw::Bool
+    throw::Bool,
 )
     throw && Base.throw(InvalidRequestError(msg))
     isnothing(nothrow_extra_logic_f) || nothrow_extra_logic_f(msg)

--- a/test/authentication.jl
+++ b/test/authentication.jl
@@ -81,7 +81,7 @@ end
             token,
             username="authfile_username",
             expires=1234,
-            email="authfile@example.org"
+            email="authfile@example.org",
         )
         # Testing the fallback to legacy GQL endpoint
         MOCK_JULIAHUB_STATE[:auth_v1_status] = 404
@@ -89,7 +89,7 @@ end
                 server;
                 token,
                 username="authfile_username",
-                email="authfile@example.org"
+                email="authfile@example.org",
             )
             @test a isa JuliaHub.Authentication
             @test a.server == server
@@ -105,7 +105,7 @@ end
             token,
             username="authfile_username",
             expires=1234,
-            email="authfile@example.org"
+            email="authfile@example.org",
         )
         # Missing username in /api/v1 -- succes, but with a warning
         delete!(MOCK_JULIAHUB_STATE, :auth_v1_status)
@@ -114,7 +114,7 @@ end
                 server;
                 token,
                 username="authfile_username",
-                email="authfile@example.org"
+                email="authfile@example.org",
             )
             @test a isa JuliaHub.Authentication
             @test a.server == server

--- a/test/batchimages.jl
+++ b/test/batchimages.jl
@@ -30,11 +30,11 @@ end
         [
             Dict(
                 "display_name" => "Stable", "type" => "base-cpu",
-                "image_key_name" => "stable-cpu"
+                "image_key_name" => "stable-cpu",
             ),
             Dict(
                 "display_name" => "Stable", "type" => "base-gpu",
-                "image_key_name" => "stable-gpu"
+                "image_key_name" => "stable-gpu",
             ),
             Dict(
                 "display_name" => "Dev", "type" => "option-cpu", "image_key_name" => "dev-cpu"

--- a/test/datasets-live.jl
+++ b/test/datasets-live.jl
@@ -70,7 +70,7 @@ try
     JuliaHub.upload_dataset(
         blobname, joinpath(TESTDATA, "hi.txt");
         description="some blob", tags=["x", "y", "z"],
-        auth
+        auth,
     )
     datasets = list_datasets_prefix(PREFIX; auth)
     @test length(datasets) == 1
@@ -89,7 +89,7 @@ try
 
     JuliaHub.upload_dataset(
         (auth.username, treename), TESTDATA;
-        description="some tree", tags=["a", "b", "c"]
+        description="some tree", tags=["a", "b", "c"],
     )
     datasets = list_datasets_prefix(PREFIX; auth)
     tree_dataset = only(filter(d -> d.name == treename, datasets))

--- a/test/datasets.jl
+++ b/test/datasets.jl
@@ -161,7 +161,7 @@ end
                 @test isdir(joinpath(pwd(), "local"))
                 @test_logs (:warn,) JuliaHub.download_dataset(
                     ("username", "blobtree/example"),
-                    "local"; replace=true
+                    "local"; replace=true,
                 )
                 @test isdir(joinpath(pwd(), "local"))
             end

--- a/test/jobs-live.jl
+++ b/test/jobs-live.jl
@@ -118,7 +118,7 @@ end
     job, _ = submit_test_job(
         JuliaHub.script"@info 1+1; sleep(200)"noenv;
         ncpu=2, memory=8,
-        auth, alias="script-simple"
+        auth, alias="script-simple",
     )
     @test job isa JuliaHub.Job
     @test job.status ∈ ("Submitted", "Running")
@@ -315,7 +315,7 @@ end
         ENV["RESULTS_FILE"] = joinpath(@__DIR__, "output.txt")
         n = write(ENV["RESULTS_FILE"], "output-txt-content")
         @info "Wrote $(n) bytes"
-        """noenv; alias="output-file",
+        """noenv; alias="output-file"
     )
     job = JuliaHub.wait_job(job)
     @test job.status == "Completed"
@@ -345,7 +345,7 @@ end
         write(joinpath(odir, "bar.txt"), "output-txt-content-2")
         @info "Wrote: odir"
         ENV["RESULTS_FILE"] = odir
-        """noenv; alias="output-file-tarball",
+        """noenv; alias="output-file-tarball"
     )
     job = JuliaHub.wait_job(job)
     @test job.status == "Completed"
@@ -386,7 +386,7 @@ end
             joinpath(@__DIR__, "jobenvs", "sysimage"),
             "script.jl";
             sysimage=true,
-        ); auth, alias="sysimage",
+        ); auth, alias="sysimage"
     )
     job = JuliaHub.wait_job(job)
     @test job.status == "Completed"

--- a/test/mocking.jl
+++ b/test/mocking.jl
@@ -293,7 +293,7 @@ function _restcall_mocked(method, url, headers, payload; query)
             "message" => Dict{String, Any}(
                 "upload_url" => "..."
             ),
-            "success" => true
+            "success" => true,
         ) |> jsonresponse(200)
     elseif (method == :GET) && occursin(GET_JOB_REGEX, url)
         jobname = match(GET_JOB_REGEX, url)[1]
@@ -315,7 +315,7 @@ function _restcall_mocked(method, url, headers, payload; query)
             job_info["status"] = "Stopped"
             Dict{String, Any}(
                 "status" => true,
-                "message" => "Job $(query.jobname) stopped successfully"
+                "message" => "Job $(query.jobname) stopped successfully",
             ) |> jsonresponse(200)
         end
     elseif (method == :POST) && endswith(url, "juliaruncloud/extend_job_time_limit")
@@ -334,7 +334,7 @@ function _restcall_mocked(method, url, headers, payload; query)
             dataset -> begin
                 version_sizes = something(
                     dataset_version_sizes,
-                    (dataset == "example-dataset") ? [57, 331] : [57]
+                    (dataset == "example-dataset") ? [57, 331] : [57],
                 )
                 Dict(
                     "version" => string("v", length(version_sizes)),
@@ -414,7 +414,7 @@ function _restcall_mocked(method, url, headers, payload; query)
             )
             Dict{String, Any}(
                 "name" => dataset,
-                "repo_id" => "df039a60-0ccc-40a7-ad31-82040a74a12a"
+                "repo_id" => "df039a60-0ccc-40a7-ad31-82040a74a12a",
             ) |> jsonresponse(200)
         else
             return JuliaHub._RESTResponse(404, "Dataset $(dataset) does not exist.")
@@ -427,7 +427,7 @@ function _restcall_mocked(method, url, headers, payload; query)
             end
             Dict{String, Any}(
                 "name" => dataset,
-                "repo_id" => "df039a60-0ccc-40a7-ad31-82040a74a12a"
+                "repo_id" => "df039a60-0ccc-40a7-ad31-82040a74a12a",
             ) |> jsonresponse(200)
         else
             return JuliaHub._RESTResponse(404, "Dataset $(dataset) does not exist.")

--- a/test/packagebundler.jl
+++ b/test/packagebundler.jl
@@ -119,7 +119,7 @@ end
     @test_logs (:warn,) match_mode = :any JuliaHub._PackageBundler.bundle(
         bundle_env;
         output=out,
-        verbose=false
+        verbose=false,
     )
     dir = mktempdir()
     Tar.extract(out, dir)
@@ -177,7 +177,7 @@ end
         bundle_env;
         output=out,
         verbose=false,
-        allownoenv=true
+        allownoenv=true,
     )
     dir = mktempdir()
     Tar.extract(out, dir)

--- a/test/utils.jl
+++ b/test/utils.jl
@@ -15,7 +15,7 @@ using Test
         throw_connecterror(), msg = "Custom message"
     )
     @test_throws msgortype(
-        "Custom interpolation 2=2\nHTTP connection to JuliaHub failed (HTTP.Exceptions.ConnectError)",
+        "Custom interpolation 2=2\nHTTP connection to JuliaHub failed (HTTP.Exceptions.ConnectError)"
     ) JuliaHub.@_httpcatch(
         throw_connecterror(), msg = "Custom interpolation $(1+1)=2"
     )


### PR DESCRIPTION
It's not so much that we merged any incorrectly formatted code, but the trailing comma formatting got fixed in JuliaFormatting (https://github.com/domluna/JuliaFormatter.jl/commit/19e6074951101616c5e2c826f755dd397fd48e25; https://github.com/domluna/JuliaFormatter.jl/issues/815). There still are some incorrectly removed trailing commas though, due to: https://github.com/domluna/JuliaFormatter.jl/issues/829