### PR TITLE
test: fix Aqua workflow

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -73,16 +73,14 @@ jobs:
       - uses: julia-actions/setup-julia@v1
         with:
           version: "1"
-      - run: |
+      - name: "Aqua.test_all(JuliaHub)"
+        shell: julia --color=yes {0}
+        run: |
           import Pkg
           Pkg.activate(temp=true)
           Pkg.add(name="Aqua", version="0.6")
           Pkg.develop(path=".")
-          import Aqua, JuliaHub
-          Aqua.test_all(JuliaHub)
-        shell: julia --color=yes {0}
-        name: "Aqua.test_all(JuliaHub)"
-        continue-on-error: true
+          include("test/aqua.jl")
 
   jet:
     name: JET

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -78,7 +78,7 @@ jobs:
         run: |
           import Pkg
           Pkg.activate(temp=true)
-          Pkg.add(name="Aqua", version="0.8")
+          Pkg.add(name="Aqua", version="0.6")
           Pkg.develop(path=".")
           include(joinpath(pwd(), "test", "aqua.jl"))
 

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -78,7 +78,7 @@ jobs:
         run: |
           import Pkg
           Pkg.activate(temp=true)
-          Pkg.add(name="Aqua", version="0.6")
+          Pkg.add(name="Aqua", version="0.8")
           Pkg.develop(path=".")
           include("test/aqua.jl")
 

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -78,7 +78,7 @@ jobs:
         run: |
           import Pkg
           Pkg.activate(temp=true)
-          Pkg.add(name="Aqua", version="0.6")
+          Pkg.add(name="Aqua", version="0.8")
           Pkg.develop(path=".")
           include(joinpath(pwd(), "test", "aqua.jl"))
 

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -80,7 +80,7 @@ jobs:
           Pkg.activate(temp=true)
           Pkg.add(name="Aqua", version="0.8")
           Pkg.develop(path=".")
-          include("test/aqua.jl")
+          include(joinpath(pwd(), "test", "aqua.jl"))
 
   jet:
     name: JET

--- a/test/aqua.jl
+++ b/test/aqua.jl
@@ -9,10 +9,7 @@ using Test
         # https://github.com/JuliaStrings/InlineStrings.jl/issues/71
         ambiguities=(;
             exclude=[
-                Base.rstrip,
-                Base.lstrip,
-                Base.unsafe_convert,
-                Base.Sort.defalg,
+                Base.Sort.defalg
             ],
         ),
         # Aqua detects missing standard library compat entries, but setting these

--- a/test/aqua.jl
+++ b/test/aqua.jl
@@ -1,0 +1,23 @@
+import Aqua
+import JuliaHub
+using Test
+
+@testset "Aqua" begin
+    Aqua.test_all(
+        JuliaHub;
+        # These ambiguities are introduced by InlineStrings
+        # https://github.com/JuliaStrings/InlineStrings.jl/issues/71
+        ambiguities=(;
+            exclude=[
+                Base.rstrip,
+                Base.lstrip,
+                Base.unsafe_convert,
+                Base.Sort.defalg,
+            ],
+        ),
+        # Aqua detects missing standard library compat entries, but setting these
+        # is problematic if we want to support 1.6
+        # https://discourse.julialang.org/t/psa-compat-requirements-in-the-general-registry-are-changing/104958
+        deps_compat=(; broken=true, check_extras=false),
+    )
+end


### PR DESCRIPTION
* `continue-on-error: true` means that the Aqua job was failing, but it didn't show up on CI (e.g. [here](https://github.com/JuliaComputing/JuliaHub.jl/actions/runs/9324670198/job/25670331246)).
* However, the errors are non-actionable, so I'm configuring Aqua to ignore these for now.

Hopefully we'll catch any future errors though.