### PR TITLE
ci: run Julia formatter on all PRs

### DIFF
--- a/.github/workflows/format-julia.yaml
+++ b/.github/workflows/format-julia.yaml
@@ -7,6 +7,8 @@ on:
       - "**.jl"
       - ".JuliaFormatter.toml"
       - ".github/workflows/format-julia.yaml"
+  # Note: no path filtering when running on PRs, since the formatter
+  # is a required check, and therefore needs to always run.
   pull_request:
     types:
       - opened

--- a/.github/workflows/format-julia.yaml
+++ b/.github/workflows/format-julia.yaml
@@ -14,10 +14,6 @@ on:
       - synchronize
       - ready_for_review
       - labeled
-    paths:
-      - "**.jl"
-      - ".JuliaFormatter.toml"
-      - ".github/workflows/format-julia.yaml"
 
 env:
   CI: true


### PR DESCRIPTION
I realized why the previous workflow did not have `on.pull_request.path` (https://github.com/JuliaComputing/JuliaHub.jl/commit/354e28992535b7021d4f23ceac22fa00cf7251d0#diff-9a9d70a0eb6f3494fd934c224bf0867c14b00d46fde8bcc4d65bb2d836898946L9) -- it's a required check, so we need to run in on all PRs, even if they don't modify Julia files.