### PR TITLE
fix: switch HTTP.jl to use MbedTLS

### DIFF
--- a/src/JuliaHub.jl
+++ b/src/JuliaHub.jl
@@ -36,6 +36,7 @@ function __init__()
     # and store the result in a global. This way all timestamps will have consistent timezones
     # even if something in the environment changes.
     _LOCAL_TZ[] = _localtz()
+    HTTP.SOCKET_TYPE_TLS[] = HTTP.MbedTLS.SSLContext
 end
 
 end


### PR DESCRIPTION
Looks like HTTP via OpenSSL.jl doesn't look up system certs .i.e doesn't respect NetworkOptions environment variables. Instead it only looks into julia bundled certs (<juliabin>/share/julia/cert.pem). However switching to MbedTLS works.