### PR TITLE
fix: correctly allow for `license=(:fulltext, ...)` in update_dataset

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,11 +2,11 @@
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## Version [v0.1.12] - 2024-??-??
+## Unreleased
 
 ### Fixed
 
-* The `JuliaHub.update_dataset` function now correctly accepts the `license=(:fulltext, ...)` argument. ()
+* The `JuliaHub.update_dataset` function now correctly accepts the `license=(:fulltext, ...)` argument. ([#74])
 
 ## Version [v0.1.11] - 2024-06-27
 
@@ -140,3 +140,4 @@ Initial package release.
 [#52]: https://github.com/JuliaComputing/JuliaHub.jl/issues/52
 [#53]: https://github.com/JuliaComputing/JuliaHub.jl/issues/53
 [#58]: https://github.com/JuliaComputing/JuliaHub.jl/issues/58
+[#74]: https://github.com/JuliaComputing/JuliaHub.jl/issues/74

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## Version [v0.1.12] - 2024-??-??
+
+### Fixed
+
+* The `JuliaHub.update_dataset` function now correctly accepts the `license=(:fulltext, ...)` argument. ()
+
 ## Version [v0.1.11] - 2024-06-27
 
 ### Added

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "JuliaHub"
 uuid = "bc7fa6ce-b75e-4d60-89ad-56c957190b6e"
 authors = ["JuliaHub Inc."]
-version = "0.1.12"
+version = "0.1.12-DEV"
 
 [deps]
 Base64 = "2a0f44e3-6c83-55bd-87e4-b1978d98bd5f"

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "JuliaHub"
 uuid = "bc7fa6ce-b75e-4d60-89ad-56c957190b6e"
 authors = ["JuliaHub Inc."]
-version = "0.1.11"
+version = "0.1.12"
 
 [deps]
 Base64 = "2a0f44e3-6c83-55bd-87e4-b1978d98bd5f"

--- a/src/datasets.jl
+++ b/src/datasets.jl
@@ -472,7 +472,7 @@ const _DOCS_datasets_metadata_fields = """
 
 !!! compat "JuliaHub.jl v0.1.12"
 
-    The `license = (:fulltext, ...)` form requires v0.1.12, and `license = (:fulltext, ...)`
+    The `license = (:fulltext, ...)` form requires v0.1.12, and `license = (:text, ...)`
     is deprecated since that version.
 """
 

--- a/src/datasets.jl
+++ b/src/datasets.jl
@@ -465,8 +465,9 @@ const _DOCS_datasets_metadata_fields = """
 * `description`: description of the dataset (a string)
 * `tags`: an iterable of strings of all the tags of the dataset
 * `visibility`: a string with possible values `public` or `private`
-* `license`: a valid SPDX license identifier, or a tuple `(:fulltext, license_text)`, where
-  `license_text` is the full text string of a custom license
+* `license`: a valid SPDX license identifier (as a string or in a
+  `(:spdx, licence_identifier)` tuple), or a tuple `(:fulltext, license_text)`,
+  where `license_text` is the full text string of a custom license
 * `groups`: an iterable of valid group names
 """
 
@@ -983,7 +984,14 @@ function update_dataset end
         cmd, license_value = license
         params["license"] = if cmd == :spdx
             Dict("spdx_id" => license_value)
-        elseif cmd == :text
+        elseif cmd in (:fulltext, :text)
+            if cmd == :text
+                Base.depwarn(
+                    "Passing license=(:text, ...) is deprecated, use license=(:fulltext, ...) instead.",
+                    :update_dataset;
+                    force=true,
+                )
+            end
             Dict("text" => license_value)
         else
             throw(ArgumentError("Invalid license argument: $(cmd) ∉ [:spdx, :text]"))

--- a/src/datasets.jl
+++ b/src/datasets.jl
@@ -469,6 +469,11 @@ const _DOCS_datasets_metadata_fields = """
   `(:spdx, licence_identifier)` tuple), or a tuple `(:fulltext, license_text)`,
   where `license_text` is the full text string of a custom license
 * `groups`: an iterable of valid group names
+
+!!! compat "JuliaHub.jl v0.1.12"
+
+    The `license = (:fulltext, ...)` form requires v0.1.12, and `license = (:fulltext, ...)`
+    is deprecated since that version.
 """
 
 """

--- a/test/datasets.jl
+++ b/test/datasets.jl
@@ -237,6 +237,24 @@ end
         @test_throws TypeError JuliaHub.update_dataset(
             "example-dataset"; description=42
         )
+        # Different options for `license` keyword
+        @test JuliaHub.update_dataset("example-dataset"; license="MIT") isa JuliaHub.Dataset
+        @test JuliaHub.update_dataset("example-dataset"; license=(:spdx, "MIT")) isa
+            JuliaHub.Dataset
+        @test JuliaHub.update_dataset("example-dataset"; license=(:fulltext, "...")) isa
+            JuliaHub.Dataset
+        # This should log a deprecation warning
+        @test @test_logs (
+            :warn,
+            "Passing license=(:text, ...) is deprecated, use license=(:fulltext, ...) instead.",
+        ) JuliaHub.update_dataset(
+            "example-dataset"; license=(:text, "...")
+        ) isa JuliaHub.Dataset
+        @test_throws TypeError JuliaHub.update_dataset("example-dataset"; license=1234)
+        @test_throws ArgumentError JuliaHub.update_dataset("example-dataset"; license=(:foo, ""))
+        @test_throws TypeError JuliaHub.update_dataset(
+            "example-dataset"; license=(:fulltext, 1234)
+        )
     end
 end
 
@@ -293,6 +311,33 @@ end
 
         # @test JuliaHub.upload_dataset(
         #     "existing-dataset", @__FILE__; update=true) isa JuliaHub.Dataset
+
+        # Different options for `license` keyword
+        @test JuliaHub.upload_dataset(
+            "example-dataset-license", @__FILE__; create=true, license="MIT"
+        ) isa JuliaHub.Dataset
+        @test JuliaHub.upload_dataset(
+            "example-dataset-license", @__FILE__; replace=true, license=(:spdx, "MIT")
+        ) isa JuliaHub.Dataset
+        @test JuliaHub.upload_dataset(
+            "example-dataset-license", @__FILE__; replace=true, license=(:fulltext, "...")
+        ) isa JuliaHub.Dataset
+        # This should log a deprecation warning
+        @test @test_logs (
+            :warn,
+            "Passing license=(:text, ...) is deprecated, use license=(:fulltext, ...) instead.",
+        ) JuliaHub.upload_dataset(
+            "example-dataset-license", @__FILE__; replace=true, license=(:text, "...")
+        ) isa JuliaHub.Dataset
+        @test_throws TypeError JuliaHub.upload_dataset(
+            "example-dataset-license", @__FILE__; replace=true, license=1234
+        )
+        @test_throws ArgumentError JuliaHub.upload_dataset(
+            "example-dataset-license", @__FILE__; replace=true, license=(:foo, "")
+        )
+        @test_throws TypeError JuliaHub.upload_dataset(
+            "example-dataset-license", @__FILE__; replace=true, license=(:fulltext, 1234)
+        )
     end
     empty!(MOCK_JULIAHUB_STATE)
 end


### PR DESCRIPTION
The `update_dataset` function (and by extension, `upload_dataset`) should, according to the documentation, accept `license = (:fulltext, ...)` when you want to set a custom license. However, this was currently implemented as `(:text, ...)`, and `:fulltext` would throw an error.

This PR fixes the implementation to correctly follow the docs and accept `license = (:fulltext, ...)`. We also keep supporting `license = (:text, ...)` as a deprecated argument as well, since this doesn't cost us much. It also adds test coverage for the `license` argument.