### PR TITLE
test: work around missing method error in JET

### DIFF
--- a/src/jobsubmission.jl
+++ b/src/jobsubmission.jl
@@ -1246,7 +1246,10 @@ function submit_job(
     else
         c.env
     end
-    args = merge(get(app, :args, Dict()), args)
+    args = merge(
+        get(app, :args, Dict())::Dict,
+        args,
+    )
 
     projectid = isnothing(c.project) ? nothing : string(c.project)
 

--- a/src/jobsubmission.jl
+++ b/src/jobsubmission.jl
@@ -1247,6 +1247,8 @@ function submit_job(
         c.env
     end
     args = merge(
+        # Note: we need to ::Dict type assertion here to avoid JET complaining with:
+        # no matching method found `convert(::Type{Dict}, ::NamedTuple)`: convert(JuliaHub.Dict, _26::NamedTuple)
         get(app, :args, Dict())::Dict,
         args,
     )


### PR DESCRIPTION
With probably 1.11, we started getting a

```
JET: JET-test failed at /home/runner/.julia/packages/JET/zHVn3/src/JET.jl:107[8](https://github.com/JuliaComputing/JuliaHub.jl/actions/runs/11589518895/job/32265190402?pr=74#step:6:9)
  Expression: (JET.report_package)("JuliaHub"; toplevel_logger = nothing, report_config = JuliaHubReportFilter())
  ═════ 1 possible error found ═════
  ┌ submit_job(app::JuliaHub.AbstractJobConfig; ncpu::Integer, ngpu::Integer, memory::Integer, nnodes::Union{…}, elastic::Bool, process_per_node::Bool, auth::JuliaHub.Authentication, kwargs...) @ JuliaHub /home/runner/work/JuliaHub.jl/JuliaHub.jl/src/jobsubmission.jl:1186
  │┌  @ JuliaHub /home/runner/work/JuliaHub.jl/JuliaHub.jl/src/jobsubmission.jl:118[9](https://github.com/JuliaComputing/JuliaHub.jl/actions/runs/11589518895/job/32265190402?pr=74#step:6:10)
  ││┌ submit_job(app::JuliaHub.AbstractJobConfig, compute::JuliaHub.ComputeConfig; name::Union{…}, alias::Union{…}, env::Any, project::Union{…}, timelimit::Union{…}, expose::Union{…}, _image_sha256::Union{…}, kwargs...) @ JuliaHub /home/runner/work/JuliaHub.jl/JuliaHub.jl/src/jobsubmission.jl:1216
  │││┌ submit_job(c::JuliaHub.WorkloadConfig) @ JuliaHub /home/runner/work/JuliaHub.jl/JuliaHub.jl/src/jobsubmission.jl:[12](https://github.com/JuliaComputing/JuliaHub.jl/actions/runs/11589518895/job/32265190402?pr=74#step:6:13)22
  ││││┌  @ JuliaHub /home/runner/work/JuliaHub.jl/JuliaHub.jl/src/jobsubmission.jl:1249
  │││││ no matching method found `convert(::Type{Dict}, ::NamedTuple)`: convert(JuliaHub.Dict, _26::NamedTuple)
  ││││└────────────────────
```

from JET. Unsure exactly why, but in this case, the type assertion also sort of functions as documentation -- the `.args` field from the `app` name tuple _should_ always be a `Dict`. So it seems file to work around the issue like this.