### PR TITLE
refactor: mark public names as public

### DIFF
--- a/src/JuliaHub.jl
+++ b/src/JuliaHub.jl
@@ -38,4 +38,28 @@ function __init__()
     _LOCAL_TZ[] = _localtz()
 end
 
+# JuliaHub.jl follows the convention that all private names are
+# prefixed with an underscore.
+function _find_public_names()
+    return filter(names(@__MODULE__; all=true)) do s
+        # Internal functions and types, prefixed by _
+        startswith(string(s), "_") && return false
+        # Internal macros, prefixed by _
+        startswith(string(s), "@_") && return false
+        # Strange generated functions
+        startswith(string(s), "#") && return false
+        # Some core functions that are not relevant for the package
+        s in [:eval, :include] && return false
+        return true
+    end
+end
+macro _mark_names_public()
+    if !Base.isdefined(Base, :ispublic)
+        return nothing
+    end
+    public_names = _find_public_names()
+    return esc(Expr(:public, public_names...))
+end
+@_mark_names_public
+
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -173,19 +173,7 @@ end
     # This set tests that we haven't accidentally added or removed any public-looking
     # functions (i.e. ones that are not prefixed by _ basically).
     @testset "Public API" begin
-        public_symbols = Set(
-            filter(names(JuliaHub; all=true)) do s
-                # Internal functions and types, prefixed by _
-                startswith(string(s), "_") && return false
-                # Internal macros, prefixed by _
-                startswith(string(s), "@_") && return false
-                # Strange generated functions
-                startswith(string(s), "#") && return false
-                # Some core functions that are not relevant for the package
-                s in [:eval, :include] && return false
-                return true
-            end,
-        )
+        public_symbols = Set(JuliaHub._find_public_names())
         expected_public_symbols = Set([
             Symbol("@script_str"),
             :AbstractJobConfig, :AbstractJuliaHubApp,
@@ -223,6 +211,18 @@ end
             extra_expected_symbols = $(sprint(show, MIME"text/plain"(), extra_expected_symbols))
             """
         @test isempty(extra_expected_symbols)
+        # Make sure that on Julia versions that support the `public` keyword,
+        # we are also marking the right symbols as public.
+        if Base.isdefined(Base, :ispublic)
+            @testset "ispublic" begin
+                for name in public_symbols
+                    @test Base.ispublic(JuliaHub, name)
+                end
+                for name in setdiff(names(JuliaHub; all=true), public_symbols)
+                    @test !Base.ispublic(JuliaHub, name)
+                end
+            end
+        end
     end
 
     @testset "Utilities" begin


### PR DESCRIPTION
JuliaHub.jl follows the convention that all private names start with `_`, so we can do the loop automatically. There is still an list in the tests that we cross-check. Also, since we support all the way back to 1.6 right now, we need to make is conditional on `Base.ispublic` being there.

Will fix these warnings:

![image](https://github.com/user-attachments/assets/d0a3ab62-e2ae-44db-ab43-2ed40fd971fd)
