### PR TITLE
feat: make DatasetVersion repr valid Julia code

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 ## Unreleased
 
+### Changed
+
+* The string `repr` of `DatasetVersion` (e.g. `dataset.versions`) is now valid Julia code. ([#84])
+
 ### Fixed
 
 * The `JuliaHub.update_dataset` function now correctly accepts the `license=(:fulltext, ...)` argument. ([#74])
@@ -141,3 +145,4 @@ Initial package release.
 [#53]: https://github.com/JuliaComputing/JuliaHub.jl/issues/53
 [#58]: https://github.com/JuliaComputing/JuliaHub.jl/issues/58
 [#74]: https://github.com/JuliaComputing/JuliaHub.jl/issues/74
+[#84]: https://github.com/JuliaComputing/JuliaHub.jl/issues/84

--- a/Makefile
+++ b/Makefile
@@ -17,6 +17,9 @@ docs-manifest:
 docs: docs/Manifest.toml
 	${JULIA} --project=docs/ docs/make.jl
 
+fix-doctests: docs/Manifest.toml
+	${JULIA} --project=docs/ docs/make.jl --fix-doctests
+
 changelog:
 	${JULIA} --project=docs/ docs/changelog.jl
 

--- a/docs/src/guides/datasets.md
+++ b/docs/src/guides/datasets.md
@@ -87,8 +87,8 @@ When downloading, you can also specify the version you wish to download (with th
 ```jldoctest example-dataset; filter = r"\"/.+/mydata\""
 julia> ds.versions
 2-element Vector{JuliaHub.DatasetVersion}:
- JuliaHub.DatasetVersion(dataset = ("username", "example-dataset"), version = 1)
- JuliaHub.DatasetVersion(dataset = ("username", "example-dataset"), version = 2)
+ JuliaHub.dataset(("username", "example-dataset")).versions[1]
+ JuliaHub.dataset(("username", "example-dataset")).versions[2]
 
 julia> ds.versions[1]
 DatasetVersion: example-dataset @ v1

--- a/src/datasets.jl
+++ b/src/datasets.jl
@@ -25,8 +25,25 @@ Objects have the following properties:
 - `.size :: Int`: size of the dataset version in bytes
 - `.timestamp :: ZonedDateTime`: dataset version timestamp
 
-```
-julia> JuliaHub.datasets()
+```jldoctest
+julia> ds = JuliaHub.dataset("example-dataset")
+Dataset: example-dataset (Blob)
+ owner: username
+ description: An example dataset
+ versions: 2
+ size: 388 bytes
+ tags: tag1, tag2
+
+julia> ds.versions
+2-element Vector{JuliaHub.DatasetVersion}:
+ JuliaHub.DatasetVersion(dataset = ("username", "example-dataset"), version = 1)
+ JuliaHub.DatasetVersion(dataset = ("username", "example-dataset"), version = 2)
+
+julia> ds.versions[end]
+DatasetVersion: example-dataset @ v2
+ owner: username
+ timestamp: 2022-10-14T01:39:43.237-04:00
+ size: 331 bytes
 ```
 
 See also: [`Dataset`](@ref), [`datasets`](@ref), [`dataset`](@ref).

--- a/src/datasets.jl
+++ b/src/datasets.jl
@@ -26,7 +26,7 @@ Objects have the following properties:
 - `.timestamp :: ZonedDateTime`: dataset version timestamp
 
 ```jldoctest
-julia> ds = JuliaHub.dataset("example-dataset")
+julia> dataset = JuliaHub.dataset("example-dataset")
 Dataset: example-dataset (Blob)
  owner: username
  description: An example dataset
@@ -34,12 +34,12 @@ Dataset: example-dataset (Blob)
  size: 388 bytes
  tags: tag1, tag2
 
-julia> ds.versions
+julia> dataset.versions
 2-element Vector{JuliaHub.DatasetVersion}:
- JuliaHub.DatasetVersion(dataset = ("username", "example-dataset"), version = 1)
- JuliaHub.DatasetVersion(dataset = ("username", "example-dataset"), version = 2)
+ JuliaHub.dataset(("username", "example-dataset")).versions[1]
+ JuliaHub.dataset(("username", "example-dataset")).versions[2]
 
-julia> ds.versions[end]
+julia> dataset.versions[end]
 DatasetVersion: example-dataset @ v2
  owner: username
  timestamp: 2022-10-14T01:39:43.237-04:00
@@ -69,14 +69,8 @@ end
 
 function Base.show(io::IO, dsv::DatasetVersion)
     owner, name = dsv._dsref
-    print(
-        io,
-        "JuliaHub.DatasetVersion(dataset = (\"",
-        owner,
-        "\", \"",
-        name,
-        "\"), version = $(dsv.id))",
-    )
+    dsref = string("(\"", owner, "\", \"", name, "\")")
+    print(io, "JuliaHub.dataset($dsref).versions[$(dsv.id)]")
 end
 function Base.show(io::IO, ::MIME"text/plain", dsv::DatasetVersion)
     owner, name = dsv._dsref

--- a/src/datasets.jl
+++ b/src/datasets.jl
@@ -63,7 +63,7 @@ struct DatasetVersion
         size = _get_json(json, "size", Int; msg)
         timestamp = _parse_tz(_get_json(json, "date", String; msg); msg)
         blobstore_path = _get_json(json, "blobstore_path", String; msg)
-        new((owner, name), version, size, timestamp, blobstore_path)
+        return new((owner, name), version, size, timestamp, blobstore_path)
     end
 end
 
@@ -71,7 +71,9 @@ function Base.show(io::IO, dsv::DatasetVersion)
     owner, name = dsv._dsref
     dsref = string("(\"", owner, "\", \"", name, "\")")
     print(io, "JuliaHub.dataset($dsref).versions[$(dsv.id)]")
+    return nothing
 end
+
 function Base.show(io::IO, ::MIME"text/plain", dsv::DatasetVersion)
     owner, name = dsv._dsref
     printstyled(io, "DatasetVersion:"; bold=true)
@@ -79,6 +81,7 @@ function Base.show(io::IO, ::MIME"text/plain", dsv::DatasetVersion)
     print(io, "\n owner: ", owner)
     print(io, "\n timestamp: ", dsv.timestamp)
     print(io, "\n size: ", dsv.size, " bytes")
+    return nothing
 end
 
 """

--- a/test/datasets.jl
+++ b/test/datasets.jl
@@ -56,6 +56,20 @@ end
             @test ds.versions[2].id == 2
             @test ds.versions[2].size == 331
 
+            # Test that .versions repr()-s to a valid array
+            # and DatasetVersion reprs to a valid JuliaHub.dataset().versions[...]
+            # call.
+            let versions = eval(Meta.parse(string(ds.versions)))
+                @test versions isa Vector{JuliaHub.DatasetVersion}
+                @test length(versions) == 2
+                @test versions == ds.versions
+            end
+            let expr = Meta.parse(string(ds.versions[1]))
+                @test expr == :((JuliaHub.dataset(("username", "example-dataset"))).versions[1])
+                version = eval(expr)
+                @test version == ds.versions[1]
+            end
+
             ds_updated = JuliaHub.dataset("example-dataset")
             @test ds_updated isa JuliaHub.Dataset
             @test ds_updated.name == ds.name


### PR DESCRIPTION
This makes sure that the short `DatasetVersion` string representation is a valid Julia code:

```
julia> dataset.versions
2-element Vector{JuliaHub.DatasetVersion}:
 JuliaHub.dataset(("username", "example-dataset")).versions[1]
 JuliaHub.dataset(("username", "example-dataset")).versions[2]
```

Also fix a doctest in the `DatasetVersion` docstring, which now in turn exercises the `show` methods for `DatasetVersion`. Also, add a `fix-doctests` Make command.