### PR TITLE
perf: add basic precompilation

### DIFF
--- a/src/JuliaHub.jl
+++ b/src/JuliaHub.jl
@@ -62,4 +62,6 @@ macro _mark_names_public()
 end
 @_mark_names_public
 
+include("precompile.jl")
+
 end

--- a/src/precompile.jl
+++ b/src/precompile.jl
@@ -1,0 +1,29 @@
+precompile(JuliaHub.authenticate, ())
+precompile(JuliaHub.authenticate, (Nothing,))
+precompile(JuliaHub.authenticate, (String,))
+precompile(JuliaHub.authenticate, (String, String))
+
+precompile(JuliaHub.datasets, ())
+precompile(JuliaHub.datasets, (String,))
+precompile(JuliaHub.dataset, (Dataset,))
+precompile(JuliaHub.dataset, (String,))
+precompile(JuliaHub.dataset, (Tuple{String,String},))
+
+precompile(JuliaHub.jobs, ())
+precompile(JuliaHub.job, (Job,))
+precompile(JuliaHub.job, (String,))
+
+precompile(JuliaHub.batchimages, ())
+precompile(JuliaHub.batchimages, (String,))
+precompile(JuliaHub.appbundle, (String,))
+precompile(JuliaHub.appbundle, (String, String))
+precompile(JuliaHub.submit_job, (WorkloadConfig,))
+
+# Precompile the basic show() methods for all public types
+for sym in JuliaHub._find_public_names()
+    t = getfield(@__MODULE__, sym)
+    if isa(t, DataType)
+        precompile(Base.show, (Base.TTY, MIME"text/plain", t))
+        precompile(Base.show, (Base.TTY, MIME"text/plain", Vector{t}))
+    end
+end


### PR DESCRIPTION
This gets "TTFA" (time-to-first-authentication) down from `5s` to `2.4s`, and TTFD (time-to-first-dataset-listing) from `~8s` to `4.5-5`. Precompilation time went from 3-4s -> 10-12s.

The test scripts was the following:

```julia
# TTFA
using JuliaHub
auth = JuliaHub.authenticate("...")
display(auth)
# + this for TTFD
datasets = JuliaHub.datasets()
display(datasets)
```

So about 50% improvement. It would be nice if it was better, but still something. As a side note: I don't see too many interesting things in `--trace-compile`, so I wonder if the rest of the compilation time are invalidations or something like that..