### PR TITLE
ci: update Julia versions in matrix

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -24,8 +24,8 @@ jobs:
       matrix:
         version:
           - "1.6"
-          - "1.8"
-          - "1.9"
+          - "1.10"
+          - "1"
           - "nightly"
         os:
           - ubuntu-latest


### PR DESCRIPTION
Run the CI on: lowest supported, LTS, latest, and nightly.