### PR TITLE
feat: receive and use tags in image options

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Added
+
+* Support for displaying and submitting batch image options with tags when working with JuliaHub instances v6.10 and above. ([#94])
+
 ## Version [v0.1.13] - 2025-04-28
 
 ### Fixed

--- a/src/batchimages.jl
+++ b/src/batchimages.jl
@@ -190,7 +190,7 @@ function _batchimages_legacy(auth::Authentication)
 end
 
 function _api_product_image_groups(auth::Authentication)
-    r = _restcall(auth, :GET, "juliaruncloud", "product_image_groups")
+    r = _restcall(auth, :GET, "juliaruncloud", "product_image_groups"; query=[("extended", "true")])
     r.status == 200 || _throw_invalidresponse(r)
     return _parse_response_json(r, Dict)
 end

--- a/src/jobsubmission.jl
+++ b/src/jobsubmission.jl
@@ -22,6 +22,7 @@ struct _JobSubmission1
     # Job image configuration
     product_name::Union{String, Nothing}
     image::Union{String, Nothing}
+    image_tag::Union{String, Nothing}
     image_sha256::Union{String, Nothing}
     sysimage_build::Union{String, Nothing}
     sysimage_manifest_sha::Union{String, Nothing}
@@ -56,6 +57,7 @@ struct _JobSubmission1
         # Job image configuration
         product_name::Union{AbstractString, Nothing}=nothing,
         image::Union{AbstractString, Nothing}=nothing,
+        image_tag::Union{AbstractString, Nothing}=nothing,
         image_sha256::Union{AbstractString, Nothing}=nothing,
         sysimage_build::Union{Bool, Nothing}=nothing,
         sysimage_manifest_sha::Union{AbstractString, Nothing}=nothing,
@@ -138,7 +140,8 @@ struct _JobSubmission1
             appbundle, appbundle_upload_info,
             registry_name, package_name, branch_name, git_revision,
             # Job image configuration
-            product_name, image, image_sha256, string(sysimage_build), sysimage_manifest_sha,
+            product_name, image, image_tag, image_sha256,
+            string(sysimage_build), sysimage_manifest_sha,
             # Compute configuration
             node_class, string(cpu),
             string(nworkers), _string_or_nothing(elastic), _string_or_nothing(min_workers_required),
@@ -1311,7 +1314,12 @@ function _job_submit_args(
             end
             batch.image._cpu_image_key
         end
-        (; product_name=batch.image.product, image)
+        (;
+            product_name=batch.image.product,
+            image,
+            image_tag=batch.image._image_tag,
+            image_sha256=batch.image._image_sha,
+        )
     else
         (;)
     end

--- a/test/mocking.jl
+++ b/test/mocking.jl
@@ -468,7 +468,7 @@ function _restcall_mocked(method, url, headers, payload; query)
         else
             serve_kafka(logengine, method, Dict(query))
         end
-    elseif (method == :GET) && endswith(url, "/juliaruncloud/product_image_groups")
+    elseif (method == :GET) && occursin("/juliaruncloud/product_image_groups", url)
         Dict(
             "image_groups" => Dict(
                 "base_and_opt" => [


### PR DESCRIPTION
Image options are being extended by tag and sha.
Previously an image option would be an image key and a type.

Now optionally an `image_tag` or `image_sha` field can appear in the image option and they should be used in job submission if chosen.
The other bigger change is that the unique constraint on options is no longer just the key, but now it's a unique constraint on key, tag and sha. This means the same key can appear multiple times with different tag/sha combinations.

This should be nonbreaking in any direction. Older client ignores the tag/sha and will just list another option with the same key. Older instances will never send tag/sha so using a newer client there is ok too.