### PR TITLE
test: winworkstation - don't check for 'default' option name specifically

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,12 +2,6 @@
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## Unreleased
-
-### Fixed
-
-* Live tests against JuliaHub 6.10 - don't check verify that the default image option name for winworkstation-batch is "default". ([#101])
-
 ## Version [v0.1.14] - 2025-06-11
 
 ### Added


### PR DESCRIPTION
In 6.10 the image option name comes from the image tag if no display name is set and now it's usually "anytag" instead of "default".
This doesn't matter too much. What matters is the option type (base-cpu/base-gpu). The display name is purely visual and shouldn't be tested against