### PR TITLE
Fix .juliabundleignore: directory patterns, comments, and content exclusion

### DIFF
--- a/src/PackageBundler/utils.jl
+++ b/src/PackageBundler/utils.jl
@@ -73,16 +73,36 @@ function is_subpath(dir, subpath)
     return startswith(norm_subpath, norm_dir)
 end
 
+# Parse a single `.juliabundleignore` line.  Returns a vector of patterns
+# (Glob.FilenameMatch or String for directory prefixes), or `nothing` for
+# blank lines and comments.  Directory patterns (trailing `/`) are split into
+# a dir match + contents match; plain prefixes use `startswith`.
+function _parse_bundleignore_line(line)
+    s = strip(line)
+    (isempty(s) || startswith(s, '#')) && return nothing
+    if endswith(s, '/')
+        has_glob = any(c -> c in ('*', '?', '['), s)
+        if has_glob
+            # Glob directory pattern: match both the dir and its contents
+            return [Glob.FilenameMatch(s), Glob.FilenameMatch(s * "*")]
+        else
+            # Plain directory prefix: use startswith matching
+            return [String(s)]
+        end
+    end
+    return [Glob.FilenameMatch(s)]
+end
+
 function get_bundleignore(file, top)
     dir = dirname(file)
     patterns = Set{Any}()
     try
         while true
             if isfile(joinpath(dir, ".juliabundleignore"))
-                union!(
-                    patterns,
-                    Glob.FilenameMatch.(strip.(readlines(joinpath(dir, ".juliabundleignore")))),
-                )
+                for line in readlines(joinpath(dir, ".juliabundleignore"))
+                    parsed = _parse_bundleignore_line(line)
+                    parsed !== nothing && union!(patterns, parsed)
+                end
                 return patterns, dir
             end
             if dir == dirname(dir) || dir == top
@@ -117,15 +137,23 @@ function path_filterer(top)
 
         patterns, ignorepath = get_bundleignore(path, top)
 
-        rpath = relpath(path, ignorepath)
+        rpath = sanitize_windows_path(relpath(path, ignorepath))
+        # Ensure rpath uses forward slashes for consistent matching
+        rpath_dir = sanitize_windows_path(joinpath(relpath(path, ignorepath), ""))
 
         return !(
-            any(p -> occursin(p, sanitize_windows_path(rpath)), patterns) ||
-            # directories specifically can be excluded by patterns that end with a
-            # path separator, and to match them in case `path` does not have that
-            # path separator appended, we append it ourselves before matching
-            isdir(path) &&
-            any(p -> occursin(p, sanitize_windows_path(joinpath(rpath, ""))), patterns)
+            any(patterns) do p
+                if p isa Glob.FilenameMatch
+                    # Glob pattern: match against the relative path
+                    occursin(p, rpath) || (isdir(path) && occursin(p, rpath_dir))
+                else
+                    # String directory prefix (e.g. "script/experiment/"):
+                    # exclude if the relative path starts with the prefix.
+                    # Only match the rpath_dir form for actual directories,
+                    # to avoid "foo.csv/" matching a FILE named "foo.csv".
+                    startswith(rpath, p) || (isdir(path) && startswith(rpath_dir, p))
+                end
+            end
         )
     end
 end

--- a/test/packagebundler.jl
+++ b/test/packagebundler.jl
@@ -240,10 +240,9 @@ end
         @test !pred(joinpath(dir, "Pkg3", "test", "foo"))
         @test pred(joinpath(dir, "Pkg3", "test", "fooo", "test"))
 
-        # Note: even though the test/foo and test/bar directories are
-        # excluded, the predicate function does not return false if you
-        # check for file within the directories.
-        @test pred(joinpath(dir, "Pkg3", "test", "bar", "test"))
+        # Directory patterns (*/bar/) now correctly exclude contents
+        @test !pred(joinpath(dir, "Pkg3", "test", "bar", "test"))
+        # */foo is a file glob (no trailing /), so only matches the file, not contents
         @test pred(joinpath(dir, "Pkg3", "test", "foo", "test"))
     end
     @testset "toplevel" begin
@@ -259,10 +258,9 @@ end
         @test !pred(joinpath(dir, "test", "foo"))
         @test pred(joinpath(dir, "test", "fooo", "test"))
 
-        # Note: even though the test/foo and test/bar directories are
-        # excluded, the predicate function does not return false if you
-        # check for file within the directories.
-        @test pred(joinpath(dir, "test", "bar", "test"))
+        # Directory patterns (*/bar/) now correctly exclude contents
+        @test !pred(joinpath(dir, "test", "bar", "test"))
+        # */foo is a file glob (no trailing /), so only matches the file, not contents
         @test pred(joinpath(dir, "test", "foo", "test"))
     end
 end


### PR DESCRIPTION
## Summary

- **Directory patterns** (e.g. `output-data/`) now correctly exclude all files inside the directory, not just the directory entry itself. Previously, `Glob.FilenameMatch("output-data/")` only matched the literal string and files inside were still bundled.
- **Comments** (`# ...`) and **blank lines** in `.juliabundleignore` are now properly skipped instead of being compiled into glob patterns.
- **File/directory ambiguity** fixed: a pattern `foo.csv/` no longer incorrectly excludes a file named `foo.csv` (only matches if it's actually a directory).

## Root cause

`get_bundleignore` passed every line through `Glob.FilenameMatch()` without filtering. `Glob.FilenameMatch("output-data/")` matches the literal string `"output-data/"` but NOT `"output-data/foo.jld2"` — so files inside ignored directories were silently bundled.

## Fix

New `_parse_bundleignore_line()` classifies each line:
- `nothing` for comments/blanks (skipped)
- `String` for plain directory prefixes → matched via `startswith`
- `Glob.FilenameMatch` for glob patterns (unchanged behavior)
- Glob-containing directory patterns (e.g. `*/bar/`) emit both the dir match and a `pattern*` contents match

## Test plan

- [x] Existing `path_filterer` tests updated (removed "known limitation" comments — the limitation is now fixed)
- [x] Existing `fixtures/bundle1` integration tests all pass (22/22 including directory exclusion)
- [x] All `bundle.*` test sets pass (0 failures)

Relates to #130 (negated paths — this PR cleans up the same code path and is a prerequisite).

🤖 Generated with [Claude Code](https://claude.com/claude-code)