### PR TITLE
[DO NOT MERGE] debug: rclone -vv --dump headers

### DIFF
--- a/src/datasets.jl
+++ b/src/datasets.jl
@@ -827,6 +827,11 @@ function _upload_dataset(upload_config, local_path; progress::Bool)
                 "--s3-no-check-bucket",
                 "--s3-no-head",
                 "--no-check-dest",
+                # DEBUG (temporary): full HTTP trace so CI surfaces the exact
+                # request/response shape that rclone is making for the failing
+                # BlobTree upload. Remove before merging.
+                "-vv",
+                "--dump", "headers",
             ]
 
             if progress


### PR DESCRIPTION
Debug branch. Enables `rclone -vv --dump headers` so CI logs show the exact HTTP exchange for the failing BlobTree upload (HeadObject 403 path).

Local Docker reproductions with the exact same Rclone_jll x86_64 binary and same session credentials all swallow the 403 and complete the upload. CI consistently fails. Need the full request/response trace from CI to find the divergence.