### PR TITLE
fix: pass --s3-no-head-object to rclone for dataset uploads

### DIFF
--- a/src/datasets.jl
+++ b/src/datasets.jl
@@ -814,18 +814,24 @@ function _upload_dataset(upload_config, local_path; progress::Bool)
             remote_path = "$bucket/$prefix"
 
             # --s3-no-check-bucket - don't check the bucket exists
+            # --s3-no-head - skip the post-upload HeadObject verification
+            # --s3-no-head-object - skip the FS-init HeadObject probe rclone
+            #   uses to detect "is this destination an existing file?". The
+            #   platform's session credentials are scoped to <prefix>/<version>/*
+            #   for BlobTree uploads and reject HEAD on the bare <version> key
+            #   with 403. From rclone v1.72 (commit rclone/rclone@6440052f,
+            #   issue rclone/rclone#8975) that 403 propagates as a fatal NewFs
+            #   error instead of being swallowed; older versions silently
+            #   treated it as "destination is a directory" and proceeded.
             # --no-check-dest - don't check whether the file exists before uploading
             #
             # Additional useful options not included here:
-            # * For restricted permissions, --s3-no-head avoids using HeadObject to
-            #   check file upload success.
             # * To force multipart upload at a smaller threshold use something like
             #   --s3-upload-cutoff 1M --s3-chunk-size 5M
-
-            # FIXME: remove `--s3-no-head` once policies are figured out (again)
             args = [
                 "--s3-no-check-bucket",
                 "--s3-no-head",
+                "--s3-no-head-object",
                 "--no-check-dest",
             ]
 


### PR DESCRIPTION
rclone v1.72 changed how its S3 backend handles a 403 from the FS-init HeadObject probe ([rclone/rclone#8975](https://github.com/rclone/rclone/issues/8975), commit [rclone/rclone@6440052f](https://github.com/rclone/rclone/commit/6440052fbdb51688dfd929ce64ff3af8ed228b29), 2025-11-18): non-NotFound errors now propagate as fatal `NewFs` failures instead of being silently treated as "this is a directory".

For BlobTree dataset uploads the platform's session credentials are scoped to `<prefix>/<version>/*` and HEAD on the bare `<version>` key is denied — so once `Rclone_jll` resolved to ≥ v1.72 (currently v1.73.5), every BlobTree upload aborted with `JuliaHubError: Data upload failed`.

The destination is always a directory in our usage, so the probe serves no purpose; suppress it with `--s3-no-head-object`.

Verified locally against `internal.juliahub.com` with `Rclone_jll` v1.73.5: the live datasets testset now passes end-to-end, where it previously failed at `datasets-live.jl:70` (BlobTree upload). The flag has existed in rclone since v1.55 (2021), so no compat impact.

Pairs with [JuliaComputing/JuliaHub#22217](https://github.com/JuliaComputing/JuliaHub/pull/22217) (server-side fix that broadens the BlobTree session policy to also authorize the bare `<version>` key); either alone resolves the failure but together they're defense in depth.