### PR TITLE
fix: stream job logs from the requested offset instead of tailing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 * Fix a `MethodError` when calling `JuliaHub.Experimental.registries`. ([#132])
 * `JuliaHub.application(s)` now handles bad API responses more gracefully. ([#133])
+* Streamed job logs (`job_logs_buffered(...; offset, stream=true)`) now resume from the requested offset instead of tailing the log, so log lines produced before the websocket connects are no longer dropped. ([#149])
 
 ## Version [v0.1.17] - 2025-12-16
 
@@ -238,3 +239,4 @@ Initial package release.
 [#127]: https://github.com/JuliaComputing/JuliaHub.jl/issues/127
 [#132]: https://github.com/JuliaComputing/JuliaHub.jl/issues/132
 [#133]: https://github.com/JuliaComputing/JuliaHub.jl/issues/133
+[#149]: https://github.com/JuliaComputing/JuliaHub.jl/issues/149

--- a/src/jobs/logging-legacy.jl
+++ b/src/jobs/logging-legacy.jl
@@ -93,7 +93,7 @@ mutable struct _LegacyLogsBuffer <: AbstractJobLogsBuffer
         end
         # If streaming was requested, we start that up. Hopefully, doing it early, will avoid
         # missing any log messages if offset was set.
-        stream && _job_logs_legacy_start_streaming!(auth, buffer)
+        stream && _job_logs_legacy_start_streaming!(auth, buffer; offset)
         return buffer
     end
 end
@@ -510,7 +510,10 @@ function _job_logs_older!(
     end
 end
 
-function _job_logs_legacy_start_streaming!(auth::Authentication, buffer::_LegacyLogsBuffer)
+function _job_logs_legacy_start_streaming!(
+    auth::Authentication, buffer::_LegacyLogsBuffer;
+    offset::Union{Integer, Nothing}=nothing,
+)
     if !isnothing(buffer._stream)
         @warn "Logs are already being streamed" buffer._jobname
         return nothing
@@ -520,10 +523,28 @@ function _job_logs_legacy_start_streaming!(auth::Authentication, buffer::_Legacy
     interrupt_channel = Channel{Nothing}(1)
     @debug "_job_logs_legacy_start_streaming!: starting websocket"
     lock(buffer) do
-        # TODO: there might be a gap between the last buffered log and the first log message
-        # that comes over the websocket. When the first websocket messages comes through, we
-        # should fill the back with a standard get_logs request.
-        t = @async _job_logs_legacy_websocket(auth, jobname) do ws, msg
+        # Work out where the stream should resume from. The server tails the log
+        # (offset = -1) when no offset is sent, which silently drops every log
+        # produced before the websocket connects -- e.g. a job that emits all
+        # its output up front and then idles. When an explicit `offset` was
+        # requested we therefore resume from the server-side eventId of the last
+        # log we already buffered (the cache line number, shared with the batch
+        # endpoint), so we neither miss those early logs nor re-stream logs the
+        # backfill already fetched. With no buffered logs yet we fall back to the
+        # requested `offset`.
+        resume_offset = if isnothing(offset)
+            nothing
+        elseif isempty(buffer._logs)
+            offset
+        else
+            last_eventid = last(buffer._logs)._legacy_eventId
+            isnothing(last_eventid) ? offset : something(tryparse(Int, last_eventid), offset)
+        end
+        # TODO: even with `resume_offset`, when offset is `nothing` (tail) there
+        # may still be a gap between the last buffered log and the first streamed
+        # message. When the first websocket message comes through, we should fill
+        # the back with a standard get_logs request.
+        t = @async _job_logs_legacy_websocket(auth, jobname; offset=resume_offset) do ws, msg
             # It's possible that older! will find the last message in some situations (particularly
             # when streaming a finished job). In that case, we want to quit the websocket.
             if buffer._found_last
@@ -573,19 +594,23 @@ function _job_logs_legacy_start_streaming!(auth::Authentication, buffer::_Legacy
     return nothing
 end
 
-function _job_logs_legacy_websocket(f::Function, auth::Authentication, jobname::AbstractString)
+function _job_logs_legacy_websocket(
+    f::Function, auth::Authentication, jobname::AbstractString;
+    offset::Union{Integer, Nothing}=nothing,
+)
     @debug "_job_log_websocket_legacy: starting task ($jobname)" _taskstamp()
     https_url = _url(auth, "ws", "stream_logs")
     ws_url = replace(https_url, r"^http://" => "ws://")
     ws_url = replace(https_url, r"^https://" => "wss://")
+    query = ["jobname" => jobname, "refresh_interval" => 1, "log_out_type" => "json"]
+    # Forward the resume offset so the server streams logs *after* this eventId
+    # instead of tailing from the current end of the log (its default when no
+    # offset is provided).
+    isnothing(offset) || push!(query, "offset" => string(offset))
     @_httpcatch HTTP.WebSockets.open(
         ws_url;
         headers=_authheaders(auth),
-        query=[
-            "jobname" => jobname,
-            "refresh_interval" => 1,
-            "log_out_type" => "json",
-        ],
+        query=query,
     ) do ws
         for msg in ws
             @debug "_job_log_websocket_legacy: message from websocket ($jobname)" _taskstamp() msg


### PR DESCRIPTION
## Problem

`JuliaHub.job_logs_buffered(job; offset=0, stream=true)` (and `job_logs` built on it) can return **zero streamed logs** even when the job produced output and the batch endpoint returns it in full.

The websocket client (`_job_logs_legacy_websocket`) only sent `jobname` / `refresh_interval` / `log_out_type` on the `/ws/stream_logs` query — it **never forwarded the `offset`** the caller requested. With no offset, logservice defaults to *tailing* the log (`offset = -1`, "start from the current end"). For a job that emits all its output up front and then idles (e.g. `@info 1+1; sleep(200)`), every log line is produced *before* the websocket connects, so the tail-start streams nothing and `buffer.logs` stays empty — while `job_logs` (batch) reads the cached log and returns all of it.

This surfaces in the nightly live test `[LIVE] JuliaHub.submit_job / simple` (`test/jobs-live.jl:166`) as `length(logbuffer.logs) > 0` failing (`0 > 0`), with the follow-up warning `full_logs=82, logbuffer.logs=0`. It became a consistent failure after the server-side log service was rewritten in Go (the connect-time behavior changed from a live read-cursor to a one-shot tail-init that skips already-cached lines).

## Fix

Forward a resume `offset` on the websocket query so the server streams logs **after** a known eventId instead of tailing:

- **Explicit offset, logs already buffered** → resume from the last buffered log's server-side `_legacy_eventId` (the cache line number, which is the *same* integer space the batch endpoint uses). This avoids both missing the early burst and re-streaming lines the backfill already fetched.
- **Explicit offset, nothing buffered yet** → fall back to the requested `offset`.
- **No offset requested** → keep tailing, exactly as before (no behavior change for `stream=true` without an offset).

## Known limitation (documented in-code)

When the buffer is empty *and* `offset=0`, the very first line (eventId 0) is still skipped, because the server streams `eventId > offset` and `-1` is overloaded as the "tail" sentinel — so "from line 0 inclusive" can't be expressed from the client. The test job loses 1 of 82 lines (so `length(logbuffer.logs) > 0` passes; the soft `full_logs == streamed_logs` equality remains a `@warn`). Fully recovering line 0 needs a small server-side change in logservice (`/ws/stream_logs`) to add a non-`-1` "from beginning" sentinel.

## Testing

- Formatter clean (JuliaFormatter v1), file parses.
- Covered by the existing live test `test/jobs-live.jl` (`[LIVE] JuliaHub.submit_job / simple`), which requires a live JuliaHub instance to run.
