### PR TITLE
test: avoid unbounded job listing in live tests

### DIFF
--- a/test/jobs-live.jl
+++ b/test/jobs-live.jl
@@ -1,4 +1,6 @@
-HIGH_JOB_LIMIT = 999999999
+# Note: the test account may well have more jobs than this, so the job listings
+# fetched with this limit are not necessarily complete.
+HIGH_JOB_LIMIT = 1000
 nodes = JuliaHub.nodespecs(; auth=auth)
 @testset "[LIVE] JuliaHub.nodespecs()" begin
     @test nodes isa Vector{JuliaHub.NodeSpec}
@@ -127,8 +129,10 @@ end
     # all the logs.
     logbuffer = JuliaHub.job_logs_buffered(job; offset=0, stream=true, auth)
 
-    jobs = JuliaHub.jobs(; limit=HIGH_JOB_LIMIT, auth)
-    @test length(jobs) > num_jobs_prev
+    # Jobs are listed latest first, so the freshly submitted job should show up
+    # in a small listing of the most recent jobs.
+    recent_jobs = JuliaHub.jobs(; limit=20, auth)
+    @test any(j -> j.id == job.id, recent_jobs)
     @test job != previous_last_job
     @test JuliaHub.job(job.id; auth).id == job.id
 


### PR DESCRIPTION
Ref: https://github.com/JuliaComputing/JuliaHub/issues/23395

The live job tests called `JuliaHub.jobs(limit=999999999)` to fetch the complete job list, twice — once up front and once after submitting a job — just to assert that the total count increased. As the test account accumulates jobs across CI runs, that full fetch gets progressively slower and heavier on the backend.

This PR:

- Caps the initial listing at `limit=1000` (only used to establish `num_jobs_prev`, whose remaining assertions are valid whether the count is exact or capped).
- Replaces the count-increase assertion after job submission with a check that the freshly submitted job's id appears in a `limit=20` listing, relying on the documented latest-first ordering of `JuliaHub.jobs`.

No coverage is lost: the limit-parameter tests (`limit=1`, `limit=3`, default limit, domain errors) are unchanged.

Note: I could not run the live suite locally (it needs an authenticated JuliaHub instance), so this should be validated by the next live-test CI run.