### PR TITLE
Update HTTP to v2 (enabled use of Bonito v5 on JuliaHub)

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -23,7 +23,7 @@ UUIDs = "cf7118a7-6976-5b1a-9a39-7adc72f591a4"
 
 [compat]
 Glob = "1"
-HTTP = "1"
+HTTP = "2"
 JSON = "0.20, 0.21, 1"
 Mocking = "0.7"
 PkgAuthentication = "2"

--- a/src/restapi.jl
+++ b/src/restapi.jl
@@ -23,7 +23,7 @@ macro _httpcatch(ex, kwargexprs...)
         try
             $(esc(ex))
         catch e
-            e isa HTTP.Exceptions.HTTPError || rethrow(e)
+            e isa HTTP.HTTPError || rethrow(e)
             throw(JuliaHubConnectionError($message, e, catch_backtrace()))
         end
     end

--- a/test/utils.jl
+++ b/test/utils.jl
@@ -1,21 +1,21 @@
 using Test
 
 @testset "@_httpcatch" begin
-    throw_connecterror() = throw(HTTP.Exceptions.ConnectError("", nothing))
+    throw_connecterror() = throw(HTTP.ConnectError("", ErrorException("")))
     @test JuliaHub.@_httpcatch(nothing) === nothing
     @test JuliaHub.@_httpcatch(nothing, msg = "...") === nothing
     msgortype(x) =
         VERSION >= v"1.8" ? "JuliaHubConnectionError: $x" : JuliaHub.JuliaHubConnectionError
-    @test_throws msgortype("HTTP connection to JuliaHub failed (HTTP.Exceptions.ConnectError)") JuliaHub.@_httpcatch(
+    @test_throws msgortype("HTTP connection to JuliaHub failed (HTTP.ConnectError)") JuliaHub.@_httpcatch(
         throw_connecterror()
     )
     @test_throws msgortype(
-        "Custom message\nHTTP connection to JuliaHub failed (HTTP.Exceptions.ConnectError)"
+        "Custom message\nHTTP connection to JuliaHub failed (HTTP.ConnectError)"
     ) JuliaHub.@_httpcatch(
         throw_connecterror(), msg = "Custom message"
     )
     @test_throws msgortype(
-        "Custom interpolation 2=2\nHTTP connection to JuliaHub failed (HTTP.Exceptions.ConnectError)"
+        "Custom interpolation 2=2\nHTTP connection to JuliaHub failed (HTTP.ConnectError)"
     ) JuliaHub.@_httpcatch(
         throw_connecterror(), msg = "Custom interpolation $(1+1)=2"
     )


### PR DESCRIPTION
- Project.toml: bumped HTTP = "2" compat

- src/restapi.jl: replaced HTTP.Exceptions.HTTPError with the non-deprecated HTTP.HTTPError (HTTP v2 deprecated the Exceptions submodule bindings in favor of top-level names).

- test/utils.jl: fixed the @_httpcatch test helper — HTTP v2's ConnectError(address, cause) now requires cause::Exception (v1 allowed cause::Any, including nothing); switched to HTTP.ConnectError and updated expected error-message strings from HTTP.Exceptions.ConnectError to HTTP.ConnectError (same underlying type, but the deprecated alias no longer affects typeof's printed name).