### PR TITLE
fix(jobsubmission): thread product_name through ApplicationJob submission

### DIFF
--- a/src/jobsubmission.jl
+++ b/src/jobsubmission.jl
@@ -1654,5 +1654,15 @@ function _job_submit_args(
         customcode=false,
         # `jr_uuid` is set to associate the running job with the application icon in the UI
         args=Dict("jobname" => appjob.app.name, "jr_uuid" => appjob.app._apptype),
+        # Omitting this left the server unable to tell which product a DefaultApp
+        # actually belongs to, so it fell back to inferring one from the deprecated
+        # `appType` field instead - ambiguous whenever multiple products share a
+        # legacy_apptype (e.g. every "batchjob"-typed product resolves to
+        # "standard-batch" regardless of which one was actually launched; see
+        # jobsubmit_common.jl's own "Deprecated submission format" warning
+        # server-side). The web frontend already sends this on every launch
+        # (LaunchButton.vue); this brings ApplicationJob submission in line with it
+        # and with how BatchJob/PackageJob already set product_name below.
+        product_name=get(appjob.app._json, "product_name", nothing),
     )
 end

--- a/test/applications.jl
+++ b/test/applications.jl
@@ -75,3 +75,24 @@ TEST_SUBMIT_APPS = [
         @test j.status == "Completed"
     end
 end
+
+# A DefaultApp whose product needs product_name to resolve correctly server-side (e.g.
+# IQOQ - see the "IQOQ Test" mock fixture in mocking.jl) must have it threaded through
+# job submission, not silently dropped. compute_type_name="cloudstation-ide" with
+# input_type_name="image" mirrors IQOQ's real product config: not classified as a batch
+# app (so it shows up here, as an ordinary application), but still product-tracked.
+@testset "_job_submit_args(ApplicationJob) threads product_name" begin
+    apiv = v"0.0.1"
+    MOCK_JULIAHUB_STATE[:api_version] = apiv
+    auth = JuliaHub.current_authentication()
+    auth._api_version = apiv
+    Mocking.apply(mocking_patch) do
+        app = JuliaHub.application(:default, "IQOQ Test"; auth)
+        @test isa(app, JuliaHub.DefaultApp)
+
+        c = JuliaHub.submit_job(app; auth, dryrun=true)
+        args = JuliaHub._job_submit_args(auth, c, c.app, JuliaHub._JobSubmission1)
+        @test args.product_name == "iqoq"
+    end
+    empty!(MOCK_JULIAHUB_STATE)
+end

--- a/test/mocking.jl
+++ b/test/mocking.jl
@@ -278,6 +278,22 @@ function _restcall_mocked(method, url, headers, payload; query)
                         "product_name" => "extra-images",
                         "appType" => "batchjob",
                     ),
+                    # Models a product whose job image runs on its own with no
+                    # user-supplied code (input_type_name="image", not "userinput"),
+                    # so it is not classified as a batch app by _is_batch_app and
+                    # shows up as an ordinary DefaultApp tile instead - like IQOQ's
+                    # real product config. Regression fixture for product_name being
+                    # threaded through ApplicationJob submission: omitting it made
+                    # the server fall back to a generic product that wrongly
+                    # demanded usercode this product's own image never needed.
+                    Dict{String, Any}(
+                        "name" => "IQOQ Test",
+                        "image_group" => "iqoq",
+                        "compute_type_name" => "cloudstation-ide",
+                        "input_type_name" => "image",
+                        "product_name" => "iqoq",
+                        "appType" => "iqoq",
+                    ),
                 ],
                 "defaultUserAppArgs" => [],
             )


### PR DESCRIPTION
## Summary

`_job_submit_args` for `BatchJob`/`PackageJob` already sends `product_name`, but the `ApplicationJob` path (`submit_job(app::DefaultApp)`) never did.

Server-side (`jobsubmit_common.jl`), omitting `product_name` falls back to inferring a product from the deprecated `appType` field — which is ambiguous whenever multiple products share a `legacy_apptype`. In the current default chart catalog alone, four products (`iqoq`, `deployment`, `standard-batch`, `standard-interactive`) share `legacy_apptype: batchjob`, so that fallback is hardcoded to always resolve to `"standard-batch"` regardless of which one was actually launched — which can require things (e.g. a usercode file) the actually-launched app's own product never did.

## Root cause investigation

This surfaced while debugging why `submit_job(JuliaHub.application(:default, "IQOQ Test"))` fails server-side with `"A usercode file needs to be provided for batch jobs"` (see JuliaComputing/JuliaHubInfra.jl#343). Two hypotheses were ruled out before landing here:

- **Not a `batchimages()`/`compute_type_name` classification bug.** IQOQ's product config (`compute_type_name: cloudstation-ide`, `legacy_apptype: batchjob`, `scheduling_type: interactive`) traces back unchanged to its original pre-chart `settings/products.json` definition, and is shared verbatim with its sibling "Post Checks" product — a deliberate, established pattern for qualification-style apps launched via the Applications tab, not a misconfiguration.
- **Confirmed the frontend already does this correctly.** `frontend/src/components/LaunchButton.vue` sends `product_name: this.app.product_name` on every launch. The web UI's "Launch IQOQ" button has never hit this bug — only this Julia client's `ApplicationJob` submission path was missing the field.

## Fix

Read `product_name` off `appjob.app._json` (the same field `_batchimages_62` already reads unconditionally from the same `defaultApps` listing) and thread it into `_job_submit_args`'s returned tuple. Uses `get(..., nothing)` rather than a required/unconditional access: `_job_params` already drops `nothing`-valued fields, so this is a no-op wherever the field is genuinely absent — including the test suite's still-present `_MISSING_API_VERSION` fixture (an API-version-less instance whose `defaultApps` entries carry no `product_name` at all), which a required access would have broken.

## Test plan

- [x] Full test suite: 2218/2218 pass
- [x] New regression test (`test/applications.jl`) using a new "IQOQ Test" mock fixture (`compute_type_name=cloudstation-ide`, `input_type_name=image`, `product_name=iqoq` — mirrors IQOQ's real config) confirms `_job_submit_args` sends `product_name` correctly for a `DefaultApp` that needs it
- [x] Existing `TEST_SUBMIT_APPS` submission tests (Pluto, RegisteredPackageApp, ExampleApp.jl) still pass unmodified