### PR TITLE
Fix remaining HTTP v2 incompatibilities on bgc-http2

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -26,7 +26,6 @@ jobs:
         # Note that we can't run too many parallel CI jobs, since the live
         # tests will run into the platform job limit.
         version:
-          - "1.6"
           - "1.10"
           - "1"
           - "nightly"

--- a/Project.toml
+++ b/Project.toml
@@ -30,7 +30,7 @@ PkgAuthentication = "2"
 Rclone_jll = "1.60"
 TimeZones = "1"
 URIs = "1"
-julia = "1.6"
+julia = "1.10"
 
 [extras]
 Logging = "56ddb016-857b-54e1-b83d-db4d58db5568"

--- a/src/jobs/jobs.jl
+++ b/src/jobs/jobs.jl
@@ -356,7 +356,7 @@ function jobs(; limit::Union{Integer, Nothing}=nothing, auth::Authentication=__a
 end
 
 function _jobs(auth::Authentication, limit::Union{Integer, Nothing}=nothing)
-    query = isnothing(limit) ? (;) : (; limit)
+    query = isnothing(limit) ? nothing : ["limit" => string(limit)]
     _restcall(auth, :GET, "juliaruncloud", "get_jobs"; query)
 end
 
@@ -557,7 +557,7 @@ function kill_job end
 kill_job(job::Job; auth::Authentication=__auth__()) = kill_job(job.id; auth)
 
 function kill_job(jobname::AbstractString; auth::Authentication=__auth__())
-    r = _restcall(auth, :GET, "juliaruncloud", "kill_job"; query=(; jobname=string(jobname)))
+    r = _restcall(auth, :GET, "juliaruncloud", "kill_job"; query=["jobname" => string(jobname)])
     if r.status == 200
         response, json = _parse_response_json(r, AbstractDict)
         # response_json["status"] might not be a Bool

--- a/src/projects.jl
+++ b/src/projects.jl
@@ -170,7 +170,7 @@ function _project_datasets(auth::Authentication, project::UUIDs.UUID)
     _assert_projects_enabled(auth)
     r = JuliaHub._restcall(
         auth, :GET, ("datasets",), nothing;
-        query=(; project=string(project)),
+        query=["project" => string(project)],
     )
     if r.status == 400
         throw(

--- a/test/mocking.jl
+++ b/test/mocking.jl
@@ -158,6 +158,12 @@ const MOCK_JULIAHUB_DEFAULT_JOB_FILES = Any[
         "type" => "project",
     ),
 ]
+# HTTP.jl v2 no longer accepts NamedTuples as the `query` argument, so `_restcall`
+# passes queries as vectors of string pairs (or `nothing`, if unset). This normalizes
+# them into a dictionary for the mock request handlers below.
+_query_dict(::Nothing) = Dict{String, String}()
+_query_dict(query) = Dict{String, String}(string(k) => string(v) for (k, v) in query)
+
 function _restcall_mocked(method, url, headers, payload; query)
     GET_JOB_REGEX = r"api/rest/jobs/([a-z0-9-]+)"
     DATASET_REGEX = r"user/datasets/([A-Za-z0-9%-]+)"
@@ -383,21 +389,22 @@ function _restcall_mocked(method, url, headers, payload; query)
         jobs = isnothing(idx) ? [] : [mock_job(idx)]
         Dict("details" => jobs) |> jsonresponse(200)
     elseif (method == :GET) && endswith(url, "juliaruncloud/get_jobs")
-        njobs = get(query, :limit, 20)
+        njobs = parse(Int, get(_query_dict(query), "limit", "20"))
         jobs_overrides = get(MOCK_JULIAHUB_STATE, :jobs, Dict{Int, Any}())
         jobs = [mock_job(i) for i = 1:njobs]
         jobs |> jsonresponse(200)
     elseif (method == :GET) && endswith(url, "juliaruncloud/kill_job")
-        idx = findfirst(isequal(query.jobname), job_names)
+        kill_jobname = _query_dict(query)["jobname"]
+        idx = findfirst(isequal(kill_jobname), job_names)
         if isnothing(idx)
             JuliaHub._RESTResponse(403, "User does not have access to this job")
         else
             jobs_overrides = get!(MOCK_JULIAHUB_STATE, :jobs, Dict{String, Any}())
-            job_info = get!(jobs_overrides, query.jobname, Dict{String, Any}())
+            job_info = get!(jobs_overrides, kill_jobname, Dict{String, Any}())
             job_info["status"] = "Stopped"
             Dict{String, Any}(
                 "status" => true,
-                "message" => "Job $(query.jobname) stopped successfully",
+                "message" => "Job $(kill_jobname) stopped successfully",
             ) |> jsonresponse(200)
         end
     elseif (method == :POST) && endswith(url, "juliaruncloud/extend_job_time_limit")
@@ -411,7 +418,7 @@ function _restcall_mocked(method, url, headers, payload; query)
     elseif (method == :GET) && endswith(url, "datasets")
         # Note: query will be `nothing` if it's unset in _restcall, so we need
         # to handle that case too.
-        project_uuid = get(something(query, (;)), :project, nothing)
+        project_uuid = get(_query_dict(query), "project", nothing)
         datasets = Dict[]
         for dataset_name in existing_datasets
             d = _dataset_json(


### PR DESCRIPTION
Follow-up to #171 — this targets the `bgc-http2` branch, not `master`.

CI on #171 is currently red on every Julia version. There are two distinct causes, both fixed here.

### 1. NamedTuple `query` arguments

HTTP v2 dropped NamedTuple support for the `query` keyword:

```
ArgumentError: unsupported query type @NamedTuple{limit::Int64}; expected String, Dict, or vector of Pair/tuples
```

Three call sites hit this at runtime:

- `src/jobs/jobs.jl:359` — `JuliaHub.jobs(; limit)` (this is the one the live tests caught, at `test/runtests-live.jl:72`)
- `src/jobs/jobs.jl:560` — `JuliaHub.kill_job`
- `src/projects.jl:173` — `_project_datasets`

All three now pass a vector of string pairs. `_restcall` already defaults `query` to `nothing`, so the no-limit case in `_jobs` uses that instead of an empty NamedTuple.

The mock handlers in `test/mocking.jl` read the query back as a NamedTuple (`get(query, :limit, 20)`, `query.jobname`, `get(something(query, (;)), :project, nothing)`), so they get a small `_query_dict` helper to normalize whatever `_restcall` passes.

### 2. `julia` compat

HTTP v2 requires Julia 1.10, but `Project.toml` still declares `julia = "1.6"`. Bumped to `"1.10"` and dropped the `"1.6"` entry from the CI matrix — that job cannot pass with HTTP v2 regardless of the code.

### Verification

Mocked suite passes locally on Julia 1.12: **2215 passed, 0 errored**. (One failure locally, at `test/jobs.jl:153`, is a `@test_logs (:warn,)` block catching spurious `Expected key "git-tree-sha1"` warnings from a corrupted registry on my machine — unrelated, and not reproducible in CI.) Live tests not run — no credentials.

### Not addressed

`UndefVarError: wait_submission not defined` at `test/jobs-applications-live.jl:9`. `wait_submission` is defined in `test/jobs-live.jl:106`, so this looks like a pre-existing live-test include-ordering issue rather than anything HTTP-related.

### Why this matters downstream

JuliaSimPM.jl is currently uninstallable — `Pkg.add(url="git@github.com:JuliaComputing/JuliaSimPM.jl.git")` fails to resolve, because it needs Bonito 5 (which requires `HTTP = "2.4.0 - 2"`) while every released JuliaHub.jl caps `HTTP = "1"`. Nothing on the JuliaSimPM side can work around this, so merging #171 and tagging a release is the fix. Note that `bgc-http2` still carries `version = "0.1.18"`, which will need a bump before it can be registered.

🤖 Generated with [Claude Code](https://claude.com/claude-code)